### PR TITLE
feat: suite completa de analytics — backend, frontend y tests

### DIFF
--- a/backend/docs/Analytics_Design_Rationale.md
+++ b/backend/docs/Analytics_Design_Rationale.md
@@ -348,28 +348,121 @@ Los endpoints de reportes (E17, E18) estructuran sus respuestas en niveles jerá
 
 ---
 
-## 4. Relación con el Dashboard Frontend
+## 4. Implementación Frontend: Suite de Analytics
 
-Este documento cubre solo la capa de backend. El frontend consumirá estos endpoints en una fase posterior. El mapeo planeado es:
+> **Estado**: Implementado — Sprint 5 (abril 2026)
+> **ADRs relacionados**: ADR-027 (Arquitectura Frontend de Analytics), ADR-028 (Composición de Componentes)
 
-| Endpoint backend | Componente frontend previsto | Tipo de visualización |
-|-----------------|------------------------------|----------------------|
-| E01 trajectory | StudentProfile → LineChart | Línea temporal con selector 7d/30d/90d |
-| E02 velocity | StudentProfile → KPI card | Indicador de aceleración/desaceleración |
-| E03 plateaus | StudentProfile → Timeline markers | Markers en el gráfico de trayectoria |
-| E04 evolution | StudentProfile → Grouped BarChart | Barras agrupadas por contexto/mecánica |
-| E05 rounds | GameplayDetail → Step chart | Gráfico paso a paso con indicador de fatiga |
-| E06 card-analysis | Dashboard → DataTable | Tabla ordenable con indicador de dificultad |
-| E07 struggles | StudentProfile → Timeline events | Marcadores de frustración en el historial |
-| E08 fatigue | Dashboard → Summary card | Resumen con % de alumnos con fatiga |
-| E09 engagement | StudentProfile → RadialChart | Gráfico radial con 5 componentes |
-| E10 classroom engagement | Dashboard → BarChart ranking | Ranking de engagement por alumno |
-| E11 play-patterns | StudentProfile → Calendar heatmap | Mapa de calor de actividad semanal |
-| E12 content-effectiveness | Dashboard → Comparative BarChart | Barras comparativas por contexto |
-| E13 card-difficulty | Dashboard → Flagged items list | Lista de tarjetas problemáticas con acción |
-| E14 learning-curves | Dashboard → Multi-line chart | Líneas superpuestas por contexto |
-| E15 alerts | Dashboard → AlertsPanel | Panel de alertas con severidad y acciones |
-| E16 alerts/summary | Sidebar → Badge | Contador de alertas activas |
-| E17 reports/student | StudentProfile → Export button | Generación de PDF client-side |
-| E18 reports/classroom | Dashboard → Export button | Generación de PDF client-side |
-| E19 reports/export | StudentsAnalytics → CSV button | Descarga directa de CSV |
+### 4.1. Arquitectura de 4 páginas
+
+El frontend consume los 26 endpoints del backend a través de `services/analytics.js` (26 métodos) y los distribuye en 4 páginas con niveles de profundidad progresiva:
+
+| Página | Ruta | Propósito | Pregunta que responde |
+|--------|------|-----------|----------------------|
+| **Dashboard** | `/dashboard` | Visión rápida (5 segundos) | "¿Cómo va mi clase hoy?" |
+| **Perfil Estudiante** | `/students/:id` | Análisis individual (2 minutos) | "¿Qué le pasa a este alumno?" |
+| **Mis Alumnos** | `/analytics/students` | Comparación de grupo | "¿Quién destaca, quién necesita apoyo?" |
+| **Insights y Reportes** | `/analytics/insights` | Análisis profundo | "¿Qué contenido funciona? ¿Qué alertas hay?" |
+
+**Justificación de 4 páginas (no 1 dashboard monolítico)**: los profesores necesitan diferentes niveles de profundidad para diferentes tareas. Un dashboard único con todo genera sobrecarga cognitiva en usuarios no técnicos. La navegación progresiva (Dashboard → click alumno → Perfil) guía al profesor de lo general a lo específico.
+
+### 4.2. Lenguaje visual: Sistema RAG como elemento firma
+
+Todas las visualizaciones comparten un **patrón de 4 capas** consistente en cada métrica:
+
+1. **Valor numérico** — el dato crudo (ej: "82%")
+2. **Indicador RAG** — semáforo visual (verde/ámbar/rojo) con los umbrales de la sección 3.4
+3. **Comparativa contextual** — contexto que da significado al dato (ej: "vs clase: 71%")
+4. **Micro-narrativa** — texto accionable (ej: "Mejorando" / "Necesita atención")
+
+Este patrón se implementa en el componente `StudentKPICard` con borde izquierdo coloreado (4px) como indicador RAG. Los profesores entienden intuitivamente el semáforo sin formación técnica.
+
+**Colores RAG**: se reutilizan los tokens OKLCH del design system existente (`--color-success-base`, `--color-warning-base`, `--color-error-base`) para mantener coherencia visual con el resto de la aplicación.
+
+### 4.3. Mapeo endpoint → componente (implementado)
+
+| Endpoint backend | Componente frontend | Página | Tipo de visualización |
+|-----------------|---------------------|--------|----------------------|
+| E01 trajectory | `TrajectoryChart` | Perfil Estudiante | LineChart con línea alumno + overlay clase punteada + badge tendencia (mejorando/estable/declinando) |
+| E02-E03 velocity/plateaus | Datos en `TrajectoryChart` | Perfil Estudiante | Indicador de confianza + detección de mesetas integrada |
+| E04 evolution | `PerformanceByDimension` | Perfil Estudiante | BarChart horizontal con barras coloreadas RAG, dos instancias: por contexto Y por mecánica |
+| E05 rounds | `GameHistoryTable` (expandible) | Perfil Estudiante | Tabla con desglose por ronda al hacer click |
+| E06 card-analysis | `ContentEffectivenessMatrix` | Insights (tab Efectividad) | Matriz grid mecánica × contexto con celdas RAG interactivas |
+| E07 struggles | Datos en `StrengthsWeaknesses` | Perfil Estudiante | Tarjetas de debilidades derivadas de datos de rendimiento |
+| E08 fatigue | `ActivityHeatmap` | Dashboard | Grid día × hora con intensidad de color (cuándo juegan) |
+| E09 engagement | `EngagementRadar` | Perfil Estudiante | RadarChart con 5 ejes (frecuencia, regularidad, completado, constancia, replays) |
+| E10 classroom engagement | Datos en `StudentsAnalytics` | Mis Alumnos | Columna de engagement en tabla comparativa |
+| E11 play-patterns | `ActivityHeatmap` + timeline | Dashboard | Heatmap semanal + timeline de actividad reciente |
+| E12 content-effectiveness | `ContentEffectivenessMatrix` | Insights (tab Efectividad) | Grid mecánica × contexto con RAG y detalle expandible |
+| E13 card-difficulty | Datos en `ContentEffectivenessMatrix` | Insights (tab Efectividad) | Integrado en la matriz de efectividad |
+| E14 learning-curves | `LearningCurvesSection` (AreaChart) | Insights (tab Efectividad) | AreaChart con múltiples líneas por contexto, eje X = intento, eje Y = score |
+| E15 alerts | `AlertsPanel` (Dashboard) + `AlertsHub` (Insights) | Dashboard + Insights | Dashboard: top 5 alertas con acción. Insights: hub completo con filtros severidad/tipo |
+| E16 alerts/summary | Sidebar badge | Navegación | Badge numérico en "Dashboard" del sidebar |
+| E17 reports/student | `ReportGenerator` | Insights (tab Informes) | Preview renderizado + exportación CSV/print |
+| E18 reports/classroom | `ReportGenerator` | Insights (tab Informes) | Preview renderizado + exportación CSV/print |
+| E19 reports/export | `exportToCSV()` | Mis Alumnos | Descarga CSV client-side con `Blob + URL.createObjectURL` |
+
+### 4.4. Justificación de decisiones de visualización
+
+#### ¿Por qué la dimensión mecánica × contexto como matriz grid?
+
+La `ContentEffectivenessMatrix` muestra mecánicas como filas y contextos como columnas, con celdas coloreadas RAG. Se eligió un grid (no un scatter plot) porque:
+- Un profesor de primaria interpreta una **tabla coloreada** (celda verde = bien, roja = mal) mucho más rápido que un gráfico abstracto
+- La dimensión mecánica × contexto es **exactamente una matriz 2D**, por lo que la representación natural es un grid
+- Permite identificar rápidamente combinaciones problemáticas (ej: "Asociación + Números tiene celda roja")
+
+#### ¿Por qué RadarChart para engagement?
+
+El `EngagementRadar` usa 5 ejes (frecuencia, regularidad, completado, constancia, replays) porque:
+- Muestra el **perfil completo** de un vistazo: un alumno con alta frecuencia pero baja regularidad se ve inmediatamente
+- Los radares son intuitivos para mostrar equilibrio/desequilibrio entre múltiples factores
+- Es visualmente diferente a los BarCharts de rendimiento, lo que ayuda a distinguir "cómo rinde" de "cuánto participa"
+
+#### ¿Por qué narrativa What/So What/Now What?
+
+El `NarrativeCard` traduce datos numéricos en lenguaje natural siguiendo el framework BI de Data Storytelling:
+- **What Happened** ("Qué pasó"): observación factual — ancla al profesor en los datos
+- **So What** ("Por qué importa"): implicación pedagógica — conecta el dato con el contexto educativo
+- **Now What** ("Qué hacer"): acción recomendada — el dato se convierte en acción
+
+Estas narrativas se generan server-side en `analyticsHelpers.js` con `generateInterpretation()` y se entregan al frontend listas para renderizar. El profesor no necesita interpretar gráficos — recibe directamente la acción sugerida.
+
+#### ¿Por qué tabla (no cards) en Mis Alumnos?
+
+Para comparación de múltiples alumnos, la tabla es superior a cards porque:
+- Permite **ordenar** por cualquier columna con un click
+- Facilita el **escaneo vertical** para encontrar valores extremos
+- Los valores están **alineados** para comparación directa
+- Es la forma más **densa** de mostrar datos multidimensionales
+
+Las cards se usan en el Perfil Individual donde cada métrica necesita más espacio visual (RAG, comparativa, narrativa).
+
+### 4.5. Estrategia de rendimiento frontend
+
+| Técnica | Implementación | Impacto |
+|---------|----------------|---------|
+| **Lazy loading** de páginas | `React.lazy()` en App.jsx | Las 3 páginas nuevas no se cargan hasta que se navega a ellas |
+| **Promise.all** para fetching | Todos los datos de cada página se piden en paralelo | Elimina waterfalls secuenciales |
+| **Catch no-bloqueante** | Datos secundarios (trajectory, engagement) con `.catch(() => null)` | Si un endpoint falla, la página muestra lo que tiene |
+| **Memoización** | `memo()` en charts, `useMemo()` en derivaciones | Evita re-renders costosos de Recharts |
+| **AbortController** | Limpieza en `useEffect` cleanup | Previene race conditions al cambiar de página o período |
+| **Skeleton loading** | Estructura idéntica al contenido final | Previene CLS (Cumulative Layout Shift) |
+| **prefers-reduced-motion** | `useReducedMotion()` hook en todos los componentes | Desactiva animaciones para usuarios sensibles al movimiento |
+
+### 4.6. Componentes reutilizables
+
+Se crearon 11 componentes en `frontend/src/components/analytics/` diseñados para composición flexible:
+
+| Componente | Responsabilidad | Reutilizado en |
+|------------|----------------|----------------|
+| `StudentKPICard` | Métrica individual con RAG 4 capas | Perfil Estudiante (6 instancias) |
+| `TrajectoryChart` | Gráfico temporal con overlay de clase | Perfil Estudiante |
+| `NarrativeCard` | Framework What/So What/Now What | Perfil Estudiante |
+| `PerformanceByDimension` | BarChart horizontal (contexto O mecánica) | Perfil Estudiante (2 instancias) |
+| `EngagementRadar` | RadarChart de 5 ejes | Perfil Estudiante |
+| `GameHistoryTable` | Tabla de historial con paginación | Perfil Estudiante |
+| `StrengthsWeaknesses` | Fortalezas/debilidades derivadas | Perfil Estudiante |
+| `ActivityHeatmap` | Grid día × hora | Dashboard |
+| `ContentEffectivenessMatrix` | Matriz mecánica × contexto RAG | Insights |
+| `AlertsHub` | Hub de alertas con filtros | Insights |
+| `ReportGenerator` | Generación de informes | Insights |

--- a/backend/docs/Analytics_Design_Rationale.md
+++ b/backend/docs/Analytics_Design_Rationale.md
@@ -466,3 +466,25 @@ Se crearon 11 componentes en `frontend/src/components/analytics/` diseñados par
 | `ContentEffectivenessMatrix` | Matriz mecánica × contexto RAG | Insights |
 | `AlertsHub` | Hub de alertas con filtros | Insights |
 | `ReportGenerator` | Generación de informes | Insights |
+
+### 4.7. Consolidación de umbrales RAG en frontend
+
+Los umbrales de clasificación RAG (score ≥70 → green, ≥50 → amber, <50 → red) y los tiers de rendimiento (≥90 excellent, ≥70 good, ≥50 average, <50 risk) estaban definidos como funciones inline en 6 archivos diferentes (StudentProfile, GameHistoryTable, PerformanceByDimension, ContentEffectivenessMatrix, ReportGenerator). Esto violaba el principio DRY y creaba riesgo de divergencia.
+
+**Decisión:** Se creó `frontend/src/constants/analyticsThresholds.js` como fuente única de verdad frontend. Exporta `scoreToTier()`, `scoreToRAG()`, `getRAGCSSColor()`, `scoreToRAGWithNull()`, `PERFORMANCE_TIERS`, `TIER_CONFIG` y `TIER_BADGE`. Los 5 componentes fueron refactorizados para importar desde este módulo.
+
+**Relación con backend:** Los valores reflejan los definidos en `analyticsHelpers.js` → `KPI_DEFINITIONS`. Si los umbrales cambian en el backend, deben actualizarse en el frontend también (documentado en el header del archivo).
+
+### 4.8. Estrategia de filtrado en Dashboard
+
+**Contexto:** T-604 requería filtros de contexto temático y mecánica de juego en el Dashboard. El servicio original `analyticsService.js` no puede modificarse (ADR-026).
+
+**Decisión:** Filtrado híbrido:
+- **Server-side** para `getClassroomStudents`: el controlador (`analyticsController.js`) pre-filtra los estudiantes que han jugado en sesiones con el contexto/mecánica seleccionados usando queries a `GameSession` + `GamePlay.distinct('playerId')`.
+- **Client-side** para componentes cuyo endpoint no acepta estos filtros: los KPIs y trends muestran datos globales de clase (que es lo pedagógicamente correcto — el profesor necesita la visión general).
+
+**Justificación:** El filtrado más granular por contenido está disponible en la página de Insights (`/analytics/insights`) con la `ContentEffectivenessMatrix`, que es el lugar natural para ese nivel de detalle. El Dashboard prioriza la visión de alto nivel.
+
+### 4.9. Cache ligero en Dashboard
+
+El Dashboard realiza 8 peticiones paralelas en cada carga. Para evitar re-fetches innecesarios (ej. al volver a la pestaña), se implementó un cache en memoria con `useRef` que almacena el timestamp del último fetch junto con la clave de filtros (`timeRange:contextId:mechanicId`). Si los datos tienen menos de 60 segundos y los filtros no han cambiado, se reutilizan los datos existentes sin hacer nuevas peticiones.

--- a/backend/docs/Analytics_Design_Rationale.md
+++ b/backend/docs/Analytics_Design_Rationale.md
@@ -1,0 +1,375 @@
+# Diseño Analítico: Justificación Pedagógica y de Business Intelligence
+
+**Fecha:** 2026-04-03
+**Autor:** Samuel Blanchart Pérez (con asistencia IA)
+**Estado:** Aprobado — Sprint 5
+**Relacionado:** ADR-017 (endpoints existentes), ADR-026 (descomposición del servicio)
+
+---
+
+## 1. Objetivo Pedagógico General
+
+### 1.1. Contexto educativo
+
+La plataforma está dirigida a **niños de 4 a 8 años** que interactúan con tarjetas RFID físicas para jugar juegos educativos de asociación y memoria. Los **profesores** — que generalmente no tienen formación técnica en análisis de datos — configuran las sesiones de juego y necesitan herramientas que les permitan:
+
+1. Entender cómo aprende cada alumno individualmente
+2. Identificar dificultades antes de que se conviertan en problemas
+3. Ajustar el material didáctico basándose en evidencia
+4. Comunicar el progreso a las familias con datos objetivos
+
+### 1.2. Evaluación formativa, no sumativa
+
+La plataforma es una herramienta de **evaluación formativa**: su propósito no es poner notas, sino informar al profesor para que pueda adaptar su enseñanza. Esto significa que:
+
+- Los datos deben traducirse en **acciones concretas** ("revisar este contenido", "dar más tiempo a este alumno")
+- Las alertas deben ser **proactivas**, no reactivas
+- Los gráficos deben ser **intuitivos** para personas sin formación técnica en datos
+- El seguimiento debe ser **longitudinal** (evolución en el tiempo), no solo instantáneo
+
+### 1.3. Principio rector
+
+> **"Cada dato que mostramos al profesor debe responder a una pregunta que puede formular en lenguaje natural."**
+
+Ejemplos:
+- "¿Cómo va Ana esta semana?" → Trayectoria (E01)
+- "¿Está mejorando o se ha estancado?" → Velocidad + Mesetas (E02, E03)
+- "¿Qué alumnos necesitan atención?" → Alertas (E15)
+- "¿Es el material adecuado o es demasiado difícil?" → Efectividad de contenido (E12, E13)
+- "¿Les motiva jugar o lo dejan a medias?" → Engagement (E09)
+
+### 1.4. Referencia
+
+La teoría de visualización y los principios de diseño de dashboards están documentados en `documentation/Dashboard.md` (principios de Data Storytelling, semántica de la visualización, selección de gráficos). Este documento se centra en el **por qué** de cada dato, no en el **cómo** se visualiza.
+
+---
+
+## 2. Justificación de cada grupo analítico
+
+### 2.1. Trayectoria de Aprendizaje (Endpoints E01-E04)
+
+#### Fundamento pedagógico
+
+El aprendizaje infantil **no es lineal**. Los niños de 4-8 años presentan patrones de progreso caracterizados por:
+- **Avances repentinos** después de periodos de aparente estancamiento
+- **Regresiones temporales** provocadas por fatiga, cambios emocionales o nuevos estímulos
+- **Ritmos distintos** según el área temática (un niño puede ser rápido en geografía y lento en matemáticas)
+
+Si el profesor solo ve una "foto" del rendimiento actual (score promedio = 65), pierde toda esta información dinámica. Necesita ver la **película completa**.
+
+#### Por qué cada endpoint
+
+| Endpoint | Pregunta que responde | Acción pedagógica |
+|----------|----------------------|-------------------|
+| **E01 — Trajectory** | "¿Cómo ha evolucionado el rendimiento de este alumno en las últimas semanas?" | Identificar si el alumno mejora, empeora o se estanca. Ajustar expectativas y planificación |
+| **E02 — Velocity** | "¿A qué ritmo está mejorando? ¿Se está acelerando o frenando?" | Un alumno con score bajo pero velocidad alta necesita paciencia, no intervención. Uno con score alto pero velocidad negativa necesita atención urgente |
+| **E03 — Plateaus** | "¿Se ha estancado? ¿Desde cuándo y por cuánto tiempo?" | Los estancamientos en educación infantil suelen indicar necesidad de cambio de estímulo: nuevo contexto, mecánica diferente, o descanso |
+| **E04 — Evolution by context/mechanic** | "¿Mejora en geografía pero no en matemáticas?" | Permite intervención focalizada por área temática en vez de intervención genérica |
+
+#### Decisión técnica: tendencia por regresión lineal
+
+La tendencia (`improving`/`declining`/`stable`) se calcula mediante el coeficiente de pendiente (slope) de una regresión lineal simple sobre los scores en el periodo. La `confidence` se basa en el número de puntos de datos (R² no es práctico con <10 puntos):
+- **high**: ≥7 data points y |slope| > 1.0
+- **medium**: 4-6 data points o |slope| entre 0.5 y 1.0
+- **low**: <4 data points o |slope| < 0.5
+
+**Justificación del umbral stable**: se considera `stable` cuando el slope está entre -0.5 y +0.5 puntos por periodo. Con scores de 0-100, una variación de ±0.5 por semana es ruido estadístico, no tendencia.
+
+---
+
+### 2.2. Análisis Profundo de Sesiones (Endpoints E05-E08)
+
+#### Fundamento pedagógico
+
+Las métricas agregadas (score total, accuracy promedio) ocultan patrones **dentro** de una partida que son críticos para entender cómo aprende un niño:
+
+- Un niño que acierta las 3 primeras rondas y falla las 3 últimas **no tiene un problema de conocimiento**, tiene un problema de **fatiga o atención**
+- Un niño que falla siempre la misma tarjeta tiene un problema **específico de contenido**, no de capacidad general
+- Dos errores seguidos pueden ser casualidad; cinco errores consecutivos son **frustración**
+
+#### Por qué cada endpoint
+
+| Endpoint | Pregunta que responde | Acción pedagógica |
+|----------|----------------------|-------------------|
+| **E05 — Rounds** | "¿Cómo fue esta partida ronda a ronda? ¿Se cansó hacia el final?" | Ajustar la duración de las sesiones. Si detecta fatiga, reducir el número de rondas |
+| **E06 — Card analysis** | "¿Hay tarjetas que todos los alumnos fallan?" | Si el error es sistemático (>50% de error en múltiples alumnos), el problema es el contenido, no el alumno. Revisar el material didáctico |
+| **E07 — Struggles** | "¿Ha tenido momentos de frustración con errores consecutivos?" | Detectar frustración temprana. En niños de 4-8 años, la frustración sostenida tiene impacto emocional real y puede generar rechazo al aprendizaje |
+| **E08 — Fatigue** | "¿Se fatigan mis alumnos durante las partidas? ¿A partir de qué ronda?" | Dato agregado de clase para ajustar la configuración global de sesiones (tiempos, número de rondas) |
+
+#### Decisión técnica: detección de fatiga
+
+La fatiga se mide comparando el **tiempo medio de respuesta** en la primera mitad de las rondas vs la segunda mitad:
+
+```
+fatigueSlowdownPercent = ((avgTimeSecondHalf - avgTimeFirstHalf) / avgTimeFirstHalf) * 100
+```
+
+- **No se detecta fatiga**: slowdown < 20% (variación normal)
+- **Fatiga leve**: 20-50% de slowdown
+- **Fatiga significativa**: >50% de slowdown
+
+**Justificación del umbral 20%**: en tests cognitivos infantiles, se considera que una variación de <20% en tiempos de respuesta está dentro de la fluctuación natural por distracción momentánea. Por encima de 20% de forma consistente, hay degradación atencional.
+
+#### Decisión técnica: índice de dificultad de tarjetas
+
+El **difficulty index** de una tarjeta se calcula como:
+
+```
+difficultyIndex = (errorCount + timeoutCount) / totalAttempts
+```
+
+Rango 0.0 (todos aciertan) a 1.0 (todos fallan). Siguiendo la convención de la Teoría Clásica de Tests (TCT):
+- **0.00-0.20**: Muy fácil — casi todos aciertan
+- **0.20-0.40**: Fácil — la mayoría acierta
+- **0.40-0.60**: Dificultad óptima — discrimina bien entre niveles
+- **0.60-0.80**: Difícil — la mayoría falla
+- **0.80-1.00**: Muy difícil — posible problema de contenido
+
+Las tarjetas con índice >0.60 en muestras de >10 alumnos deben ser revisadas por el profesor.
+
+---
+
+### 2.3. Métricas de Engagement (Endpoints E09-E11)
+
+#### Fundamento pedagógico
+
+**El rendimiento (score) no mide motivación.** Un alumno puede obtener buenas puntuaciones pero estar perdiendo interés. Las señales de desengagement en niños de 4-8 años incluyen:
+
+- Jugar con menos frecuencia
+- No terminar las partidas (abandono)
+- No volver a jugar voluntariamente
+- Aumentar el tiempo entre sesiones
+
+Estas señales son **predictivas**: la caída de engagement precede a la caída de rendimiento. Si el profesor las detecta a tiempo, puede intervenir antes de que el problema se refleje en las notas.
+
+#### Composición del Engagement Score
+
+El score (0-100) combina 5 factores con pesos diferenciados:
+
+| Factor | Peso | Justificación |
+|--------|------|---------------|
+| **Tasa de completado** | 0.30 | No terminar juegos es la señal más fuerte de desinterés. Peso mayor porque es el indicador más fiable y menos ambiguo |
+| **Frecuencia de juego** | 0.25 | Jugar regularmente indica motivación sostenida |
+| **Regularidad** | 0.25 | Distribución uniforme vs ráfagas. Jugar 10 partidas en 1 día y nada en 6 no es lo mismo que 1-2 al día |
+| **Tiempo entre sesiones** | 0.10 | Complemento de frecuencia. Peso menor porque depende de factores externos (horario escolar) |
+| **Replays voluntarios** | 0.10 | Repetir un juego por elección propia indica motivación intrínseca. Peso moderado porque no todos los niños tienen la oportunidad |
+
+**Normalización**: cada factor se normaliza a 0-100 antes de aplicar el peso:
+- Frecuencia: `min(gamesPerWeek / 5, 1) * 100` (5+ juegos/semana = máximo)
+- Regularidad: `(díasActivos / díasTotales) * 100`
+- Completado: `(completados / total) * 100`
+- Tiempo entre sesiones: `max(1 - (avgDaysBetween / 7), 0) * 100` (7+ días = mínimo)
+- Replays: `min(replayCount / 3, 1) * 100` (3+ replays = máximo)
+
+#### Análisis de abandono
+
+El abandono de partidas merece análisis separado porque sus causas son diversas:
+- **Abandono en rondas tempranas (1-2)**: posible confusión con la mecánica o el contenido
+- **Abandono en rondas medias**: posible frustración por dificultad
+- **Abandono en rondas finales**: menos preocupante (posible interrupción externa)
+
+Se analiza el `currentRound` en partidas abandonadas y el contexto donde más se abandona, para distinguir entre problemas de contenido y problemas de duración.
+
+---
+
+### 2.4. Efectividad de Contenido (Endpoints E12-E14)
+
+#### Fundamento pedagógico
+
+El análisis de datos no solo evalúa al alumno — **evalúa el material**. Un profesor necesita saber:
+
+- "¿Este contexto temático funciona para enseñar?" → Si los scores no mejoran con repetición, el contenido no está enseñando
+- "¿Hay tarjetas mal diseñadas?" → Si una tarjeta tiene >60% de error en todos los alumnos, el problema es la tarjeta
+- "¿Cuál es la curva de aprendizaje de cada contenido?" → ¿Cuántas veces necesita jugar un niño para dominar un tema?
+
+#### Por qué cada endpoint
+
+| Endpoint | Pregunta que responde | Acción pedagógica |
+|----------|----------------------|-------------------|
+| **E12 — Content effectiveness** | "¿Qué contextos/mecánicas producen mejor aprendizaje?" | Priorizar contenidos efectivos y revisar los que no funcionan |
+| **E13 — Card difficulty** | "¿Hay tarjetas específicas que son demasiado difíciles?" | Revisar o reemplazar tarjetas problemáticas. No culpar al alumno cuando el material es el problema |
+| **E14 — Learning curves** | "¿Mejoran los niños con la repetición de un contenido?" | Si la curva es plana (no mejoran con repetición), el formato de enseñanza no funciona para ese tema |
+
+#### Decisión técnica: curvas de aprendizaje
+
+Las curvas se construyen numerando secuencialmente las partidas de cada alumno para un contexto determinado (1ª vez, 2ª vez, 3ª vez...) y promediando scores entre alumnos en cada "número de intento":
+
+```
+playNumber=1: promedio de todos los scores en su 1ª partida de "Geografía"
+playNumber=2: promedio de todos los scores en su 2ª partida de "Geografía"
+...
+```
+
+El **learning rate** es la pendiente de esta curva. Una curva con pendiente positiva significa que los niños aprenden con la repetición. Una curva plana o descendente indica un problema con el contenido.
+
+El **plateau point** (`plateauAt`) indica el número de partida tras el cual la mejora se estabiliza. Es útil para saber cuántas repeticiones son productivas antes de que los rendimientos sean decrecientes.
+
+---
+
+### 2.5. Sistema de Alertas Inteligentes (Endpoints E15-E16)
+
+#### Fundamento pedagógico
+
+Los profesores **no tienen tiempo** de revisar gráficos a diario para cada alumno. Las alertas son el puente entre los datos y la acción. En educación infantil, la intervención temprana es especialmente crítica porque:
+
+- Los patrones negativos se consolidan rápidamente a estas edades
+- La ventana de atención es corta: si un niño se desanima, puede ser difícil reconectarlo
+- Los profesores gestionan 20-30 alumnos simultáneamente
+
+#### Tipos de alerta y justificación de umbrales
+
+| Tipo | Umbral | Severidad | Justificación |
+|------|--------|-----------|---------------|
+| `declining_performance` | Bajada >10% en 7 días | warning (10-20%), critical (>20%) | <10% es fluctuación normal día a día. >10% sostenido en 7 días indica tendencia real, no ruido |
+| `inactivity` | >7 días sin jugar | info (7-14d), warning (>14d) | 7 días = más de una semana lectiva completa. Si un alumno no juega en todo ese tiempo, algo ha cambiado |
+| `sudden_score_drop` | Score >30 puntos bajo la media del alumno | warning | 30 puntos en una escala de 0-100 es una desviación de ~2σ. Indica una partida anómala que merece revisión |
+| `consistent_timeout` | Tasa de timeout >30% en últimas 5 partidas | warning | Los timeouts no son errores de conocimiento, son señales de confusión o desatención. 30% sostenido en 5 partidas no es accidental |
+| `improving_fast` | Mejora >15% en 7 días | info (positiva) | Alerta positiva para que el profesor refuerce el progreso del alumno. El reconocimiento es crucial en educación infantil |
+| `plateau_detected` | Sin mejora significativa en periodo configurable | info | Reutiliza la lógica de E03. El profesor puede decidir cambiar de estímulo |
+| `high_abandonment` | Tasa de abandono >25% en 7 días | warning | 1 de cada 4 juegos abandonados indica un problema sistemático, no un incidente aislado |
+
+#### Decisión técnica: computación on-the-fly vs almacenamiento
+
+Las alertas se **computan en tiempo real** (con cache de 10 minutos) en vez de almacenarse en base de datos:
+
+- **Ventaja**: los datos siempre están frescos y no hay riesgo de inconsistencia
+- **Ventaja**: no requiere migraciones ni modelo de datos nuevo
+- **Trade-off**: cada consulta ejecuta múltiples queries en paralelo (6-7 queries ligeras)
+- **Mitigación**: cache de 600 segundos + queries optimizadas que usan `User.studentMetrics` (datos pre-agregados) cuando es posible
+
+Se genera un ID estable para cada alerta (`hash(type + studentId + fecha)`) para que el frontend pueda trackear el estado de "leído/no leído" en localStorage sin necesidad de persistencia server-side.
+
+---
+
+### 2.6. Datos para Reportes y Exportación (Endpoints E17-E19)
+
+#### Fundamento pedagógico
+
+Los datos **deben poder salir de la plataforma** para ser útiles en contextos no digitales:
+
+- **Reuniones con familias**: el profesor necesita un informe comprensible del progreso del niño
+- **Coordinación con orientadores**: si se detecta una dificultad, los datos objetivos ayudan al diagnóstico
+- **Informes de evaluación**: muchos centros requieren documentación formal del progreso
+
+#### Diseño de los reportes
+
+- **Reporte de estudiante (E17)**: combina todos los sub-servicios en una sola respuesta. Incluye overview, trayectoria, rendimiento por contexto/mecánica, historial de partidas, momentos de dificultad y alertas activas. Diseñado para ser renderizado como PDF client-side.
+- **Reporte de clase (E18)**: visión macro con distribución, tendencias, contenido más y menos efectivo, y resumen por alumno.
+- **Exportación tabular (E19)**: formato plano (headers + rows) optimizado para generación de CSV client-side con `Blob + URL.createObjectURL`. Columnas en español para el usuario final.
+
+---
+
+## 3. Decisiones Arquitectónicas
+
+### 3.1. Descomposición del servicio de analytics
+
+El `analyticsService.js` actual tiene **1092 líneas** con 11 funciones. Añadir 19 endpoints más lo llevaría a ~3000+ líneas, haciéndolo difícil de mantener, testear y revisar.
+
+**Decisión**: crear sub-servicios temáticos bajo `services/analytics/` sin modificar el servicio existente. Cada sub-servicio tiene responsabilidad única y es testeable de forma aislada.
+
+**Justificación detallada en ADR-026.**
+
+### 3.2. No se crean campos nuevos en los modelos
+
+Toda la información analítica se **deriva** de datos que ya existen:
+- `GamePlay.events[]` contiene el log completo de cada partida
+- `GamePlay.metrics` tiene los contadores agregados
+- `User.studentMetrics` tiene estadísticas pre-computadas por alumno
+- `GameSession.cardMappings` tiene la asignación tarjeta→valor
+
+**Ventaja**: zero migraciones, zero riesgo de inconsistencia, zero cambios en el flujo de escritura.
+
+**Solo se añaden índices** para optimizar las nuevas queries de lectura:
+- `GamePlay: { playerId: 1, status: 1, startedAt: -1 }` — para queries de engagement que necesitan partidas abandonadas
+- `GameSession: { createdBy: 1, contextId: 1 }` — para lookups de contenido por profesor
+
+### 3.3. Computación de alertas on-the-fly con cache
+
+Ver sección 2.5 para la justificación completa. En resumen: frescura de datos + simplicidad > reducción marginal de queries.
+
+### 3.4. Framework KPI: umbrales RAG e interpretación automática
+
+Todos los endpoints de analytics enriquecen sus respuestas con:
+
+1. **Estado RAG** (Red/Amber/Green) — clasificación visual inmediata para el profesor
+2. **Interpretación automática** — texto en español siguiendo el patrón "What / So What / Now What" del framework de Business Intelligence
+
+#### Definiciones de KPI con umbrales
+
+Cada métrica tiene umbrales formales definidos en `analyticsHelpers.js → KPI_DEFINITIONS`:
+
+| KPI | Unidad | Dirección | Green (OK) | Red (Alarma) | Target |
+|-----|--------|-----------|------------|--------------|--------|
+| `score` | puntos | higher_better | ≥70 | <50 | 75 |
+| `accuracy` | % | higher_better | ≥75 | <50 | 80 |
+| `engagementScore` | puntos | higher_better | ≥60 | <35 | 70 |
+| `completionRate` | % | higher_better | ≥85 | <60 | 90 |
+| `abandonmentRate` | % | lower_better | ≤10 | >25 | 5 |
+| `responseTime` | ms | lower_better | ≤4000 | >8000 | 3000 |
+| `fatigueSlowdown` | % | lower_better | ≤15 | >40 | 10 |
+| `cardErrorRate` | % | lower_better | ≤30 | >60 | 20 |
+| `learningRate` | pts/intento | higher_better | ≥2 | <0 | 3 |
+| `trendSlope` | pts/periodo | higher_better | ≥0.5 | <-0.5 | 1.0 |
+
+#### Justificación de umbrales
+
+- **Score 70/50**: basado en los PERFORMANCE_TIERS existentes (ADR-017). 70 = "bueno", 50 = "riesgo"
+- **Accuracy 75/50**: 75% significa 3 de cada 4 aciertos, nivel razonable para 4-8 años. <50% es prácticamente aleatorio
+- **Engagement 60/35**: derivado empíricamente de los pesos del score compuesto. Un alumno que juega 3 veces/semana con 80% de completado obtiene ~60
+- **Response time 4s/8s**: basado en estudios de atención infantil. Niños de 4-8 años responden en 2-5s en tareas familiares
+- **Fatigue 15%/40%**: <15% es variación normal de atención. >40% indica degradación significativa
+
+#### Patrón "What / So What / Now What"
+
+Cada interpretación sigue tres niveles adaptados al público (profesores sin formación técnica):
+
+- **What**: observación factual del dato ("Tasa de acierto del 62%")
+- **So What**: significado pedagógico ("Acierta más de la mitad pero comete errores frecuentes")
+- **Now What**: acción recomendada ("Revisar qué tarjetas o conceptos causan más fallos")
+
+Las interpretaciones varían según el estado RAG: verde = refuerzo positivo, ámbar = monitorización, rojo = intervención.
+
+#### Jerarquía visual en reportes
+
+Los endpoints de reportes (E17, E18) estructuran sus respuestas en niveles jerárquicos siguiendo el principio "Summary → Trends → Details":
+
+1. **Nivel 1 — Summary**: KPIs principales con RAG (lo que el profesor ve primero)
+2. **Nivel 2 — Trends**: gráficos de tendencia temporal
+3. **Nivel 3 — Engagement**: participación y análisis de abandono
+4. **Nivel 4 — Details**: desglose completo (solo en formato `detailed`)
+
+### 3.5. Estrategia de caching diferenciada
+
+| Tipo de dato | TTL | Razón |
+|-------------|-----|-------|
+| Alertas y reportes | 600s (10 min) | Computación costosa (múltiples queries paralelas). 10 minutos es aceptable porque las alertas no necesitan ser instantáneas |
+| Engagement y contenido (classroom) | 300s (5 min) | Consultas que agregan datos de toda la clase. Cambian con cada partida pero el profesor no necesita datos al segundo |
+| Datos individuales de estudiante | 300s (5 min) | Pueden cambiar tras cada partida pero el impacto visual en un gráfico de semanas es mínimo |
+
+---
+
+## 4. Relación con el Dashboard Frontend
+
+Este documento cubre solo la capa de backend. El frontend consumirá estos endpoints en una fase posterior. El mapeo planeado es:
+
+| Endpoint backend | Componente frontend previsto | Tipo de visualización |
+|-----------------|------------------------------|----------------------|
+| E01 trajectory | StudentProfile → LineChart | Línea temporal con selector 7d/30d/90d |
+| E02 velocity | StudentProfile → KPI card | Indicador de aceleración/desaceleración |
+| E03 plateaus | StudentProfile → Timeline markers | Markers en el gráfico de trayectoria |
+| E04 evolution | StudentProfile → Grouped BarChart | Barras agrupadas por contexto/mecánica |
+| E05 rounds | GameplayDetail → Step chart | Gráfico paso a paso con indicador de fatiga |
+| E06 card-analysis | Dashboard → DataTable | Tabla ordenable con indicador de dificultad |
+| E07 struggles | StudentProfile → Timeline events | Marcadores de frustración en el historial |
+| E08 fatigue | Dashboard → Summary card | Resumen con % de alumnos con fatiga |
+| E09 engagement | StudentProfile → RadialChart | Gráfico radial con 5 componentes |
+| E10 classroom engagement | Dashboard → BarChart ranking | Ranking de engagement por alumno |
+| E11 play-patterns | StudentProfile → Calendar heatmap | Mapa de calor de actividad semanal |
+| E12 content-effectiveness | Dashboard → Comparative BarChart | Barras comparativas por contexto |
+| E13 card-difficulty | Dashboard → Flagged items list | Lista de tarjetas problemáticas con acción |
+| E14 learning-curves | Dashboard → Multi-line chart | Líneas superpuestas por contexto |
+| E15 alerts | Dashboard → AlertsPanel | Panel de alertas con severidad y acciones |
+| E16 alerts/summary | Sidebar → Badge | Contador de alertas activas |
+| E17 reports/student | StudentProfile → Export button | Generación de PDF client-side |
+| E18 reports/classroom | Dashboard → Export button | Generación de PDF client-side |
+| E19 reports/export | StudentsAnalytics → CSV button | Descarga directa de CSV |

--- a/backend/docs/Architecture_Decisions.md
+++ b/backend/docs/Architecture_Decisions.md
@@ -1784,3 +1784,83 @@ Para vistas de consulta (mazos, sesiones, wizard), se usa un badge compacto (`Au
 - **Positivas**: Audio vinculado al asset, gestión individual (añadir/reemplazar/eliminar), indicadores de audio cross-app, sin archivos huérfanos
 - **Negativas**: Pestaña "Audio" eliminada del UploadAssetModal (ya no se pueden crear assets solo-audio desde la UI)
 - **Retrocompatibilidad**: Assets solo-audio existentes siguen funcionando; el smart delete los elimina correctamente
+
+---
+
+## ADR-026: Descomposición modular del servicio de Analytics
+
+**Estado**: Aprobado
+**Fecha**: 03-04-2026
+
+### Contexto (ADR-026)
+
+El servicio `analyticsService.js` alcanzó 1092 líneas con 11 funciones tras la implementación de ADR-017 (endpoints de analytics para dashboard). El Sprint 5 requiere añadir 19 nuevos endpoints analíticos que cubren trayectorias de aprendizaje, análisis de sesiones, engagement, efectividad de contenido, alertas inteligentes y datos de exportación.
+
+Añadir estas funciones al servicio monolítico lo llevaría a ~3000+ líneas, con problemas de:
+- **Mantenibilidad**: funciones de dominios distintos (alertas, engagement, contenido) en un solo archivo
+- **Testabilidad**: dificultad para testear un dominio sin cargar todo el servicio
+- **Code review**: un archivo de 3000 líneas es difícil de revisar en PRs
+- **Paralelismo de trabajo**: dos desarrolladores no pueden trabajar simultáneamente en engagement y alertas sin conflictos
+
+### Decisión (ADR-026)
+
+Se descompone la funcionalidad **nueva** en sub-servicios temáticos bajo `services/analytics/`, preservando el servicio existente intacto:
+
+```
+services/
+  analyticsService.js              ← INTACTO (11 funciones, 1092 líneas)
+  analytics/
+    analyticsHelpers.js            ← Utilidades compartidas
+    studentTrajectoryService.js    ← 4 funciones (trajectory, velocity, plateaus, evolution)
+    sessionAnalysisService.js      ← 4 funciones (rounds, cardAnalysis, struggles, fatigue)
+    engagementService.js           ← 3 funciones (student, classroom, playPatterns)
+    contentEffectivenessService.js ← 3 funciones (effectiveness, cardDifficulty, learningCurves)
+    alertsService.js               ← 2 funciones (alerts, alertsSummary)
+    reportDataService.js           ← 3 funciones (studentReport, classroomReport, exportData)
+    index.js                       ← Re-exporta todos los sub-servicios
+```
+
+**Principios clave:**
+
+1. **No se modifica `analyticsService.js`**: Las 11 funciones existentes permanecen idénticas. Zero riesgo de regresión en los endpoints actuales.
+2. **Controller separado**: Los nuevos handlers van en `analyticsAdvancedController.js`, no en el controller existente.
+3. **Helpers compartidos**: Las utilidades que usan múltiples sub-servicios (cálculo de date ranges, clasificación de tiers, constantes de performance) se extraen a `analyticsHelpers.js`.
+4. **Mismos patrones**: Los sub-servicios usan los mismos repositories, cacheHelper, ownershipHelpers y logger que el servicio original.
+
+### Alternativas Consideradas (ADR-026)
+
+1. **Ampliar el servicio monolítico**: Simplemente añadir funciones a `analyticsService.js`. Rechazado por los problemas de mantenibilidad descritos.
+
+2. **Refactorizar todo (mover funciones existentes)**: Mover las 11 funciones existentes a sub-servicios y dejar `analyticsService.js` como orquestador. Rechazado porque:
+   - Introduce riesgo de regresión innecesario en endpoints que funcionan correctamente
+   - Requiere actualizar todos los imports del controller existente
+   - No aporta beneficio inmediato (las 11 funciones existentes son un conjunto cohesivo)
+
+3. **Patrón Strategy por tipo de analytics**: Crear una interfaz `AnalyticsStrategy` con implementaciones por dominio. Rechazado porque:
+   - Sobre-ingeniería para un servicio de lectura (no hay polimorfismo real en las queries)
+   - El patrón de funciones exportadas de Node.js es más simple y directo
+
+### Consecuencias (ADR-026)
+
+**Positivas:**
+- Cada sub-servicio tiene 250-400 líneas → fácil de entender y revisar
+- Tests unitarios aislados por dominio
+- Nuevo controller dedicado evita saturar el existente (165 líneas → ~450 sería el nuevo)
+- Los imports son explícitos: `require('../services/analytics/alertsService')`
+- El servicio original sigue funcionando sin cambios para el frontend actual
+
+**Negativas:**
+- Duplicación conceptual de imports (cacheHelper, logger, repositories) en cada sub-servicio
+- 8 archivos nuevos en vez de 1
+- Si en el futuro se quiere unificar, requiere consolidación
+
+### Relación con otros ADRs
+
+- **ADR-017**: Los 11 endpoints existentes y sus funciones en `analyticsService.js` no se modifican
+- **ADR-014**: Los nuevos handlers usan `sendSuccess` de responseHelper
+- **ADR-013**: Los nuevos handlers usan `asyncHandler` del flujo de errores centralizado
+- **ADR-020**: Los nuevos endpoints usan `cacheGet` de cacheHelper con la misma estrategia de TTL
+
+### Documento de Diseño
+
+La justificación pedagógica y de Business Intelligence detallada (por qué cada endpoint, qué pregunta responde al profesor, justificación de umbrales) se documenta en `backend/docs/Analytics_Design_Rationale.md`.

--- a/backend/docs/Architecture_Decisions.md
+++ b/backend/docs/Architecture_Decisions.md
@@ -1958,3 +1958,52 @@ La suite de analytics requiere 10+ componentes nuevos con patrones compartidos (
 **Negativas:**
 - Múltiples fetches pueden hacer más peticiones al backend (mitigado por caché Redis server-side)
 - Sin store global, cambiar de página pierde el estado (comportamiento esperado — cada vista es independiente)
+
+## ADR-029: Consolidación de umbrales RAG y filtrado híbrido en Dashboard
+
+**Fecha:** 2026-04-06
+**Estado:** Aceptado
+**Contexto:** ADR-026, ADR-027, ADR-028
+
+### Situación
+
+Dos problemas identificados durante la revisión de la suite de analytics:
+
+1. **Umbrales RAG duplicados**: Los mismos magic numbers de clasificación (score ≥70 → green, ≥50 → amber; score ≥90 → excellent, ≥70 → good, ≥50 → average) estaban definidos como funciones inline en 6 archivos frontend diferentes. Riesgo de divergencia y violación DRY.
+
+2. **Filtros de contenido en Dashboard**: T-604 requería filtros de contexto temático y mecánica de juego, pero `analyticsService.js` no puede modificarse (ADR-026).
+
+### Decisiones
+
+**1. Módulo compartido de umbrales:**
+- Crear `frontend/src/constants/analyticsThresholds.js` como fuente única de verdad frontend
+- Exportar funciones de clasificación: `scoreToTier()`, `scoreToRAG()`, `getRAGCSSColor()`, `scoreToRAGWithNull()`
+- Exportar constantes: `PERFORMANCE_TIERS`, `TIER_CONFIG`, `TIER_BADGE`
+- Refactorizar 5 componentes para importar desde este módulo
+
+**2. Filtrado híbrido:**
+- **Server-side** en `analyticsController.js` para `getClassroomStudents`: pre-filtra por sessionIds que coincidan con contexto/mecánica, luego filtra los estudiantes que jugaron en esas sesiones
+- **KPIs y trends sin filtrar**: muestran datos globales de clase (pedagógicamente correcto, el profesor necesita la visión general)
+- El filtrado granular por contenido permanece en `/analytics/insights` con la `ContentEffectivenessMatrix`
+
+**3. Cache ligero en Dashboard:**
+- `useRef` con timestamp de último fetch y clave de filtros
+- TTL de 60 segundos para evitar re-fetches en tab-focus
+- Reduce las 8 peticiones paralelas a solo cuando los datos están realmente obsoletos
+
+### Alternativas descartadas
+
+- **Modificar `analyticsService.js`**: Descartada por ADR-026 (zero regresión)
+- **Filtrado 100% client-side por contenido**: Los datos de estudiantes son agregados (avgScore) y no contienen desglose por contexto, por lo que filtrar no tendría sentido semántico
+- **Store global (Redux/Zustand)**: Sobreingeniería para el caso de uso — cada página es independiente
+
+### Consecuencias
+
+**Positivas:**
+- Fuente única de verdad para umbrales → eliminación de divergencia
+- Filtros funcionales sin romper ADR-026
+- Reducción de peticiones redundantes al backend
+
+**Negativas:**
+- Los umbrales frontend deben actualizarse manualmente si cambian en el backend (documentado en el header del archivo)
+- El filtro de contenido no afecta a KPIs/trends (mitigado: la página de Insights cubre este caso)

--- a/backend/docs/Architecture_Decisions.md
+++ b/backend/docs/Architecture_Decisions.md
@@ -1864,3 +1864,97 @@ services/
 ### Documento de Diseño
 
 La justificación pedagógica y de Business Intelligence detallada (por qué cada endpoint, qué pregunta responde al profesor, justificación de umbrales) se documenta en `backend/docs/Analytics_Design_Rationale.md`.
+
+---
+
+## ADR-027: Arquitectura Frontend de Analytics — Suite de 4 Páginas
+
+### Contexto (ADR-027)
+
+El backend (ADR-017, ADR-026) dispone de 26 endpoints de analytics con framework KPI completo (RAG, narrativas What/So What/Now What, 10 KPIs con umbrales). Sin embargo, el frontend solo consumía 6 de esos 26 endpoints. El dashboard mostraba datos mock en `StudentsList`, la distribución recibía `null`, y los trends eran strings hardcodeados. Los profesores no tenían forma de hacer seguimiento individual de alumnos ni de analizar la efectividad del contenido por la dimensión mecánica × contexto.
+
+### Decisión (ADR-027)
+
+Construir una suite completa de analytics frontend con **4 páginas** y un lenguaje visual RAG uniforme:
+
+1. **Dashboard mejorado** (`/dashboard`): 8 KPIs con datos reales y trends calculados, alertas inteligentes del backend (7 tipos, 3 severidades), heatmap de actividad semanal (día × hora), timeline de actividad reciente, distribución real de rendimiento.
+
+2. **Perfil Individual de Estudiante** (`/students/:studentId`): KPIs con indicador RAG y comparativa con clase, trayectoria de aprendizaje con overlay de promedio de clase e indicador de tendencia (mejorando/estable/declinando), narrativa BI auto-generada (Qué pasó / Por qué importa / Qué hacer), rendimiento por contexto temático Y por mecánica de juego con barras coloreadas RAG, engagement score, historial de partidas, fortalezas y debilidades derivadas automáticamente.
+
+3. **Vista Comparativa** (`/analytics/students`): Tabla interactiva ordenable/filtrable con métricas, búsqueda por nombre, filtro por tier, indicadores de actividad coloreados, resumen con distribución, y exportación CSV client-side.
+
+4. **Insights y Reportes** (`/analytics/insights`): Matriz de efectividad mecánica × contexto con colores RAG, curvas de aprendizaje por contenido, hub centralizado de alertas con filtros, y generación de informes (clase/individual) con exportación.
+
+### Alternativas descartadas
+
+1. **Dashboard único con todo**: Descartado porque la sobrecarga cognitiva para profesores no técnicos es excesiva. Los profesores necesitan diferentes niveles de profundidad para diferentes tareas (visión rápida vs. seguimiento individual vs. análisis profundo).
+
+2. **Tablas sin visualización**: Descartado porque los profesores de infantil/primaria necesitan patrones visuales intuitivos (semáforos, barras de colores), no números crudos.
+
+3. **5+ páginas separadas**: Descartado para evitar fragmentación de la navegación. Los 3 aspectos de Insights (efectividad, alertas, informes) comparten contexto temporal y se resuelven mejor con tabs.
+
+### Justificación pedagógica
+
+- **Sistema RAG (semáforo)**: Lenguaje visual universal en educación — verde/ámbar/rojo se interpreta intuitivamente sin formación.
+- **Narrativas What/So What/Now What**: Framework BI que traduce datos en acciones pedagógicas concretas, reduciendo carga cognitiva del profesor.
+- **Dimensión mecánica × contexto**: Cada juego combina una mecánica (Asociación, Memoria) con un contexto temático (Animales, Números, Banderas). Sin cruzar ambas dimensiones, los promedios ocultan patrones críticos (ej: alumno domina memoria con animales pero falla en asociación con números).
+- **Comparativa con clase**: Los números aislados no tienen significado para un profesor. "82%" no dice nada; "82% (vs clase: 71%)" da contexto.
+
+### Componentes reutilizables creados
+
+| Componente | Propósito | Ubicación |
+|------------|-----------|-----------|
+| `StudentKPICard` | KPI con RAG 4 capas (valor, semáforo, comparativa, narrativa) | `components/analytics/` |
+| `TrajectoryChart` | LineChart con tendencia + overlay clase | `components/analytics/` |
+| `NarrativeCard` | What/So What/Now What | `components/analytics/` |
+| `PerformanceByDimension` | BarChart horizontal (contexto O mecánica) | `components/analytics/` |
+| `GameHistoryTable` | Tabla de historial con badge RAG | `components/analytics/` |
+| `StrengthsWeaknesses` | Fortalezas/debilidades derivadas | `components/analytics/` |
+| `ActivityHeatmap` | Grid día × hora de actividad | `components/analytics/` |
+| `ContentEffectivenessMatrix` | Grid mecánica × contexto RAG | `components/analytics/` |
+| `AlertsHub` | Hub completo de alertas con filtros | `components/analytics/` |
+| `ReportGenerator` | Interfaz de generación de informes | `components/analytics/` |
+
+### Estrategia de rendimiento
+
+- **Fetching sin waterfalls**: `Promise.all` para datos independientes. Datos secundarios (trajectory, engagement) como `.catch(() => null)` para no bloquear.
+- **Bundle optimization**: Páginas lazy-loaded con `React.lazy`. Recharts (~390KB) en chunk separado.
+- **Re-render optimization**: `memo()` en componentes de chart, `useMemo()` para derivaciones, `useCallback()` para handlers.
+- **Animaciones**: Solo donde aceleran comprensión. `prefers-reduced-motion` respetado via `useReducedMotion`.
+
+### Relación con otros ADRs
+
+- **ADR-017** y **ADR-026**: Los 26 endpoints del backend son consumidos completos por esta suite frontend
+- **ADR-003**: Los DTOs del backend se mapean directamente a props de componentes
+- **ADR-012**: Las tarjetas RFID se referencian por UID en el análisis de dificultad de tarjetas
+
+---
+
+## ADR-028: Estrategia de Composición de Componentes de Analytics
+
+### Contexto (ADR-028)
+
+La suite de analytics requiere 10+ componentes nuevos con patrones compartidos (RAG colors, comparativa con clase, animaciones condicionales). Sin una estrategia de composición clara, se arriesga duplicación de lógica y boolean prop proliferation.
+
+### Decisión (ADR-028)
+
+1. **Patrón RAG como elemento firma**: Cada métrica en cada página sigue el patrón de 4 capas: valor numérico + indicador RAG (borde/dot) + comparativa contextual + micro-narrativa. Implementado en `StudentKPICard` con props explícitos (`ragStatus`, `comparison`, `comparisonPositive`).
+
+2. **Explicit variants en vez de boolean props**: `PerformanceByDimension` acepta `dimension="context"` o `dimension="mechanic"` en vez de `isContext={true}`. Cada variante tiene su comportamiento explícito.
+
+3. **Datos derivados durante render**: Alertas, filtros, y fortalezas/debilidades se derivan con `useMemo` durante render, no en `useEffect`. Evita efectos secundarios innecesarios y re-renders extra.
+
+4. **Fetch strategy por página**: Cada página hace su propio fetch con `Promise.all` y `AbortController`. No hay store global de analytics — cada vista es autosuficiente.
+
+5. **Tokens RAG del design system existente**: Se reutilizan `--color-success-base`, `--color-warning-base`, `--color-error-base` de los tokens OKLCH ya definidos en `index.css`. No se crea una segunda paleta.
+
+### Consecuencias
+
+**Positivas:**
+- Componentes autocontenidos: cada uno es testeable y reutilizable
+- Sin prop drilling complejo: datos pasan directo del fetch al componente
+- Lenguaje visual consistente en toda la suite gracias al patrón RAG
+
+**Negativas:**
+- Múltiples fetches pueden hacer más peticiones al backend (mitigado por caché Redis server-side)
+- Sin store global, cambiar de página pierde el estado (comportamiento esperado — cada vista es independiente)

--- a/backend/seeders/06-sessions.js
+++ b/backend/seeders/06-sessions.js
@@ -136,73 +136,146 @@ function generateBoardLayout(cardMappings) {
  * Cada template define que tipo de sesion crear.
  * Incluye variedad de estados para datos mas realistas.
  */
+/**
+ * Templates de sesiones distribuidas en 60 días para alimentar analytics avanzados.
+ * Incluye variedad temporal, mecánicas y estados (completed, created).
+ * El seeder de gameplays (07) generará partidas para las sesiones completed.
+ *
+ * Criterios BI:
+ * - Suficientes sesiones para trends de 7d, 30d y 90d
+ * - Múltiples contextos y mecánicas para content-effectiveness
+ * - Distribución temporal para heatmaps y trayectorias
+ * - Sesiones recientes y antiguas para detección de tendencias
+ */
 const sessionTemplates = [
+  // ─── Semana 8-9 (hace ~56-60 días) — inicio del periodo ───
   {
     contextKey: 'geography-europe',
     mechanicName: 'association',
-    config: {
-      numberOfRounds: 6,
-      timeLimit: 20,
-      pointsPerCorrect: 10,
-      penaltyPerError: -2
-    },
+    config: { numberOfRounds: 6, timeLimit: 20, pointsPerCorrect: 10, penaltyPerError: -2 },
     status: 'completed',
-    description: 'Asociación con países de Europa',
-    daysAgo: 10
-  },
-  {
-    contextKey: 'animals-farm',
-    mechanicName: 'association',
-    config: {
-      numberOfRounds: 6,
-      timeLimit: 15,
-      pointsPerCorrect: 10,
-      penaltyPerError: -3
-    },
-    status: 'completed',
-    description: 'Animales de granja - repaso',
-    daysAgo: 8
+    description: 'Geografía Europa - sesión inicial',
+    daysAgo: 58
   },
   {
     contextKey: 'colors-basic',
     mechanicName: 'association',
-    config: {
-      numberOfRounds: 6,
-      timeLimit: 12,
-      pointsPerCorrect: 10,
-      penaltyPerError: -2
-    },
+    config: { numberOfRounds: 5, timeLimit: 12, pointsPerCorrect: 10, penaltyPerError: -2 },
     status: 'completed',
-    description: 'Colores básicos - práctica',
-    daysAgo: 6
+    description: 'Colores básicos - primera sesión',
+    daysAgo: 55
   },
+  // ─── Semana 6-7 (hace ~42-49 días) ───
+  {
+    contextKey: 'animals-farm',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 15, pointsPerCorrect: 10, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Animales de granja - introducción',
+    daysAgo: 47
+  },
+  {
+    contextKey: 'geography-europe',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 20, pointsPerCorrect: 10, penaltyPerError: -2 },
+    status: 'completed',
+    description: 'Geografía Europa - repaso 1',
+    daysAgo: 42
+  },
+  // ─── Semana 4-5 (hace ~28-35 días) ───
   {
     contextKey: 'numbers-1-6',
     mechanicName: 'association',
-    config: {
-      numberOfRounds: 5,
-      timeLimit: 25,
-      pointsPerCorrect: 15,
-      penaltyPerError: -5
-    },
-    // Sesion recien creada, aun sin iniciar
-    status: 'created',
-    description: 'Números del 1 al 6 - asociación',
-    daysAgo: 1
+    config: { numberOfRounds: 5, timeLimit: 25, pointsPerCorrect: 15, penaltyPerError: -5 },
+    status: 'completed',
+    description: 'Números 1-6 - primera sesión',
+    daysAgo: 33
+  },
+  {
+    contextKey: 'colors-basic',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 12, pointsPerCorrect: 10, penaltyPerError: -2 },
+    status: 'completed',
+    description: 'Colores básicos - repaso',
+    daysAgo: 28
   },
   {
     contextKey: 'shapes-basic',
     deckName: 'Formas Memoria',
     mechanicName: 'memory',
-    config: {
-      numberOfRounds: 5,
-      timeLimit: 20,
-      pointsPerCorrect: 20,
-      penaltyPerError: -3
-    },
+    config: { numberOfRounds: 5, timeLimit: 20, pointsPerCorrect: 20, penaltyPerError: -3 },
     status: 'completed',
-    description: 'Memoria con formas básicas',
-    daysAgo: 2
+    description: 'Memoria con formas - introducción',
+    daysAgo: 26
+  },
+  // ─── Semana 3 (hace ~18-22 días) ───
+  {
+    contextKey: 'animals-farm',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 15, pointsPerCorrect: 10, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Animales de granja - repaso',
+    daysAgo: 21
+  },
+  {
+    contextKey: 'geography-europe',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 18, pointsPerCorrect: 12, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Geografía Europa - repaso 2',
+    daysAgo: 18
+  },
+  // ─── Semana 2 (hace ~10-14 días) ───
+  {
+    contextKey: 'numbers-1-6',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 20, pointsPerCorrect: 15, penaltyPerError: -5 },
+    status: 'completed',
+    description: 'Números 1-6 - repaso',
+    daysAgo: 12
+  },
+  {
+    contextKey: 'shapes-basic',
+    deckName: 'Formas Memoria',
+    mechanicName: 'memory',
+    config: { numberOfRounds: 6, timeLimit: 18, pointsPerCorrect: 20, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Memoria con formas - repaso',
+    daysAgo: 10
+  },
+  {
+    contextKey: 'colors-basic',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 12, pointsPerCorrect: 10, penaltyPerError: -2 },
+    status: 'completed',
+    description: 'Colores - práctica avanzada',
+    daysAgo: 8
+  },
+  // ─── Semana 1 (hace ~3-6 días) — más reciente ───
+  {
+    contextKey: 'animals-farm',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 15, pointsPerCorrect: 10, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Animales de granja - evaluación',
+    daysAgo: 5
+  },
+  {
+    contextKey: 'geography-europe',
+    mechanicName: 'association',
+    config: { numberOfRounds: 6, timeLimit: 18, pointsPerCorrect: 12, penaltyPerError: -3 },
+    status: 'completed',
+    description: 'Geografía Europa - evaluación final',
+    daysAgo: 3
+  },
+  // ─── Sesiones pendientes (para testing de estados) ───
+  {
+    contextKey: 'numbers-1-6',
+    mechanicName: 'association',
+    config: { numberOfRounds: 5, timeLimit: 25, pointsPerCorrect: 15, penaltyPerError: -5 },
+    status: 'created',
+    description: 'Números 1-6 - sesión programada',
+    daysAgo: 0
   }
 ];
 

--- a/backend/seeders/07-gameplays.js
+++ b/backend/seeders/07-gameplays.js
@@ -1,6 +1,16 @@
 /**
  * @fileoverview Seeder de partidas individuales (GamePlay).
- * Crea partidas de ejemplo con eventos y métricas para testing.
+ * Genera partidas con eventos y métricas realistas para alimentar 30 endpoints de analytics.
+ *
+ * Mejoras sobre versión anterior:
+ * - Rango temporal: 60 días (antes: 10 días)
+ * - Partidas por alumno: 8-15 (antes: 2-5)
+ * - Estados: completed + abandoned (antes: solo completed)
+ * - Re-intentos: misma sesión jugada múltiples veces
+ * - Patrones temporales: variabilidad entre días
+ * - Fatiga simulada: tiempos crecientes en rondas finales
+ *
+ * Ver backend/docs/Analytics_Design_Rationale.md para contexto de BI.
  * @module seeders/07-gameplays
  */
 
@@ -9,37 +19,107 @@ const GameSession = require('../src/models/GameSession');
 const User = require('../src/models/User');
 const logger = require('../src/utils/logger');
 
-function getProfileConfig(studentProfile, round, numberOfRounds) {
-  if (studentProfile === 'high_performer') {
-    return {
-      successProb: 0.95,
-      timeoutProb: 0.01,
-      avgSpeed: 2500
-    };
-  }
+// ══════════════════════════════════════════════════════════════════════
+// Perfiles de estudiante con soporte para evolución temporal
+// ══════════════════════════════════════════════════════════════════════
 
-  if (studentProfile === 'struggling') {
-    return {
-      successProb: 0.4,
-      timeoutProb: 0.15,
-      avgSpeed: 8000
-    };
-  }
-
-  if (studentProfile === 'improving') {
-    const progress = round / numberOfRounds;
-    return {
-      successProb: 0.3 + progress * 0.6,
-      timeoutProb: 0.2 - progress * 0.15,
-      avgSpeed: 8000 - progress * 4000
-    };
-  }
-
-  return {
-    successProb: 0.78,
+/**
+ * Perfiles de estudiante extendidos para analytics avanzados.
+ * Cada perfil define cómo varía el rendimiento en el tiempo.
+ */
+const STUDENT_PROFILES = {
+  high_performer: {
+    label: 'Alto rendimiento estable',
+    baseSuccessProb: 0.92,
+    timeoutProb: 0.02,
+    avgSpeed: 2500,
+    // Tendencia: estable, ligera mejora
+    improvementPerGame: 0.005,
+    fatigueMultiplier: 1.15,
+    abandonProbability: 0.02
+  },
+  improving: {
+    label: 'Mejorando progresivamente',
+    baseSuccessProb: 0.45,
+    timeoutProb: 0.12,
+    avgSpeed: 6500,
+    // Tendencia: mejora clara
+    improvementPerGame: 0.04,
+    fatigueMultiplier: 1.3,
+    abandonProbability: 0.08
+  },
+  declining: {
+    label: 'Rendimiento en descenso',
+    baseSuccessProb: 0.75,
+    timeoutProb: 0.05,
+    avgSpeed: 3500,
+    // Tendencia: empeora
+    improvementPerGame: -0.025,
+    fatigueMultiplier: 1.4,
+    abandonProbability: 0.12
+  },
+  plateau: {
+    label: 'Estancado',
+    baseSuccessProb: 0.65,
     timeoutProb: 0.06,
-    avgSpeed: 4000
-  };
+    avgSpeed: 4500,
+    // Tendencia: estable sin mejora
+    improvementPerGame: 0.002,
+    fatigueMultiplier: 1.2,
+    abandonProbability: 0.05
+  },
+  struggling: {
+    label: 'Con dificultades',
+    baseSuccessProb: 0.35,
+    timeoutProb: 0.18,
+    avgSpeed: 8000,
+    // Tendencia: ligera mejora pero lenta
+    improvementPerGame: 0.015,
+    fatigueMultiplier: 1.5,
+    abandonProbability: 0.15
+  },
+  average: {
+    label: 'Rendimiento medio',
+    baseSuccessProb: 0.72,
+    timeoutProb: 0.06,
+    avgSpeed: 4000,
+    // Tendencia: mejora moderada
+    improvementPerGame: 0.02,
+    fatigueMultiplier: 1.25,
+    abandonProbability: 0.06
+  }
+};
+
+const PROFILE_NAMES = Object.keys(STUDENT_PROFILES);
+
+// ══════════════════════════════════════════════════════════════════════
+// Funciones de generación de eventos
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Genera la configuración de rendimiento para una ronda específica,
+ * considerando el perfil del alumno, su progresión y la fatiga.
+ *
+ * @param {Object} profile - Perfil STUDENT_PROFILES[key]
+ * @param {number} gameNumber - Número de partida (para progresión temporal)
+ * @param {number} round - Ronda actual
+ * @param {number} numberOfRounds - Total de rondas
+ * @returns {Object} { successProb, timeoutProb, avgSpeed }
+ */
+function getProfileConfig(profile, gameNumber, round, numberOfRounds) {
+  // Progresión temporal: el alumno mejora/empeora con cada partida
+  const progression = Math.min(gameNumber * profile.improvementPerGame, 0.3);
+  const successProb = Math.max(0.1, Math.min(0.98, profile.baseSuccessProb + progression));
+  const timeoutProb = Math.max(0.01, profile.timeoutProb - progression * 0.3);
+
+  // Fatiga: los tiempos aumentan en las rondas finales
+  const roundProgress = round / numberOfRounds;
+  const fatigueEffect =
+    roundProgress > 0.5 ? 1 + (roundProgress - 0.5) * (profile.fatigueMultiplier - 1) * 2 : 1;
+
+  const avgSpeed = profile.avgSpeed * fatigueEffect;
+
+  return { successProb, timeoutProb, avgSpeed };
 }
 
 function resolveRoundResult({ random, successProb, timeoutProb, finalSpeed, config }) {
@@ -73,11 +153,9 @@ function resolveCardUid(eventType, expectedMapping, errorMapping) {
   if (eventType === 'error') {
     return errorMapping.uid;
   }
-
   if (eventType === 'correct') {
     return expectedMapping.uid;
   }
-
   return undefined;
 }
 
@@ -85,7 +163,6 @@ function resolveActualValue(eventType, expectedMapping, errorMapping) {
   if (eventType === 'correct') {
     return expectedMapping.assignedValue;
   }
-
   return errorMapping.assignedValue;
 }
 
@@ -98,40 +175,49 @@ function buildRoundEvents({
   pointsAwarded,
   timeElapsed
 }) {
-  const roundStartEvent = {
-    timestamp: new Date(roundStartTime),
-    eventType: 'round_start',
-    roundNumber: round
-  };
-
-  const resultEvent = {
-    timestamp: new Date(roundStartTime + timeElapsed),
-    eventType,
-    cardUid: resolveCardUid(eventType, expectedMapping, errorMapping),
-    expectedValue: expectedMapping.assignedValue,
-    actualValue: resolveActualValue(eventType, expectedMapping, errorMapping),
-    pointsAwarded,
-    timeElapsed,
-    roundNumber: round
-  };
-
-  const roundEndEvent = {
-    timestamp: new Date(roundStartTime + timeElapsed + 500),
-    eventType: 'round_end',
-    roundNumber: round
-  };
-
-  return [roundStartEvent, resultEvent, roundEndEvent];
+  return [
+    {
+      timestamp: new Date(roundStartTime),
+      eventType: 'round_start',
+      roundNumber: round
+    },
+    {
+      timestamp: new Date(roundStartTime + timeElapsed),
+      eventType,
+      cardUid: resolveCardUid(eventType, expectedMapping, errorMapping),
+      expectedValue: expectedMapping.assignedValue,
+      actualValue: resolveActualValue(eventType, expectedMapping, errorMapping),
+      pointsAwarded,
+      timeElapsed,
+      roundNumber: round
+    },
+    {
+      timestamp: new Date(roundStartTime + timeElapsed + 500),
+      eventType: 'round_end',
+      roundNumber: round
+    }
+  ];
 }
 
 /**
- * Genera eventos coherentes para una partida simulando diferentes perfiles de estudiante.
- * @param {number} numberOfRounds - Número de rondas
+ * Genera eventos para una partida.
+ *
+ * @param {number} numberOfRounds - Rondas de la sesión
  * @param {Object} config - Configuración de la sesión
- * @param {string} studentProfile - Perfil del alumno ('high_performer', 'struggling', 'improving', 'average')
- * @returns {Object} Objeto con eventos y métricas
+ * @param {Array} cardMappings - Mapeos de tarjetas
+ * @param {Object} profile - Perfil STUDENT_PROFILES[key]
+ * @param {number} gameNumber - Número de partida (para progresión)
+ * @param {boolean} willAbandon - Si la partida será abandonada
+ * @returns {Object} { events, score, metrics, roundsPlayed }
  */
-function generatePlayEvents(numberOfRounds, config, cardMappings, studentProfile = 'average') {
+function generatePlayEvents(
+  numberOfRounds,
+  config,
+  cardMappings,
+  profile,
+  gameNumber,
+  willAbandon
+) {
   const events = [];
   let score = 0;
   let correctAttempts = 0;
@@ -139,22 +225,25 @@ function generatePlayEvents(numberOfRounds, config, cardMappings, studentProfile
   let timeoutAttempts = 0;
   const responseTimes = [];
 
-  // Jitter determinista basado en el numero de rondas
-  const jitter = (numberOfRounds * 7919) % 60000;
+  // Si abandona, jugar solo una parte de las rondas
+  const roundsToPlay = willAbandon
+    ? Math.max(1, Math.floor(numberOfRounds * (0.3 + Math.random() * 0.4)))
+    : numberOfRounds;
+
+  const jitter = (numberOfRounds * 7919 + gameNumber * 1237) % 60000;
   const startTime = Date.now() - numberOfRounds * 20000 - jitter;
 
-  for (let round = 1; round <= numberOfRounds; round++) {
+  for (let round = 1; round <= roundsToPlay; round++) {
     const roundStartTime = startTime + (round - 1) * 15000;
 
     const { successProb, timeoutProb, avgSpeed } = getProfileConfig(
-      studentProfile,
+      profile,
+      gameNumber,
       round,
       numberOfRounds
     );
 
     const random = Math.random();
-
-    // Simular variabilidad en el tiempo de respuesta
     const speedJitter = Math.random() * 2000 - 1000;
     const finalSpeed = Math.max(1000, avgSpeed + speedJitter);
 
@@ -180,20 +269,19 @@ function generatePlayEvents(numberOfRounds, config, cardMappings, studentProfile
       responseTimes.push(timeElapsed);
     }
 
-    const roundEvents = buildRoundEvents({
-      roundStartTime,
-      round,
-      eventType,
-      expectedMapping,
-      errorMapping,
-      pointsAwarded,
-      timeElapsed
-    });
-
-    events.push(...roundEvents);
+    events.push(
+      ...buildRoundEvents({
+        roundStartTime,
+        round,
+        eventType,
+        expectedMapping,
+        errorMapping,
+        pointsAwarded,
+        timeElapsed
+      })
+    );
   }
 
-  // Calcular métricas
   const averageResponseTime =
     responseTimes.length > 0
       ? Math.round(responseTimes.reduce((a, b) => a + b, 0) / responseTimes.length)
@@ -203,21 +291,24 @@ function generatePlayEvents(numberOfRounds, config, cardMappings, studentProfile
     events,
     score: Math.max(0, score),
     metrics: {
-      totalAttempts: numberOfRounds,
+      totalAttempts: roundsToPlay,
       correctAttempts,
       errorAttempts,
       timeoutAttempts,
       averageResponseTime,
-      completionTime: numberOfRounds * 15000
-    }
+      completionTime: roundsToPlay * 15000
+    },
+    roundsPlayed: roundsToPlay
   };
 }
 
+// ══════════════════════════════════════════════════════════════════════
+// Generación de partidas con distribución temporal realista
+// ══════════════════════════════════════════════════════════════════════
+
 /**
- * Genera partidas para las sesiones activas.
- * @param {Array} sessions - Sesiones creadas
- * @param {Array} students - Alumnos creados
- * @returns {Array} Array de datos de partidas
+ * Genera partidas distribuidas temporalmente para analytics avanzados.
+ * Cada alumno recibe 8-15 partidas distribuidas en 60 días.
  */
 function generateGamePlaysData(sessions, students) {
   const gamePlays = [];
@@ -232,8 +323,6 @@ function generateGamePlaysData(sessions, students) {
     return acc;
   }, {});
 
-  const profiles = ['high_performer', 'average', 'struggling', 'improving', 'average'];
-
   students.forEach((student, index) => {
     const teacherId = (student.assignedTeacher || student.createdBy || '').toString();
     const teacherSessions = sessionsByTeacher[teacherId] || [];
@@ -241,45 +330,77 @@ function generateGamePlaysData(sessions, students) {
       return;
     }
 
-    // Determinista: 2-5 partidas por alumno segun su indice
-    const playsCount = (index % 4) + 2;
+    // Asignar perfil determinista: cicla por los 6 perfiles
+    const profileName = PROFILE_NAMES[index % PROFILE_NAMES.length];
+    const profile = STUDENT_PROFILES[profileName];
+
+    // 8-15 partidas por alumno (determinista, más que antes)
+    const playsCount = 8 + (index % 8);
+
+    // Ordenar sesiones por fecha para distribuir partidas temporalmente
+    const sortedSessions = [...teacherSessions].sort(
+      (a, b) => (a.startedAt || a.createdAt) - (b.startedAt || b.createdAt)
+    );
+
     for (let i = 0; i < playsCount; i++) {
-      const session = teacherSessions[(index + i) % teacherSessions.length];
+      // Distribuir entre sesiones (con re-intentos — misma sesión jugada varias veces)
+      const session = sortedSessions[i % sortedSessions.length];
       const numberOfRounds = session.config.numberOfRounds;
-      const profile = profiles[(index + i) % profiles.length];
+
+      // Decidir si abandona (según perfil)
+      const willAbandon = Math.random() < profile.abandonProbability;
+
       const playData = generatePlayEvents(
         numberOfRounds,
         session.config,
         session.cardMappings,
-        profile
+        profile,
+        i,
+        willAbandon
       );
 
-      const sessionStart = session.startedAt || new Date();
-      const timeShift = sessionStart.getTime() - playData.events[0].timestamp.getTime();
+      // Calcular timestamp: distribuir partidas del alumno a lo largo del tiempo
+      const sessionStart = session.startedAt || session.createdAt || new Date();
+
+      // Añadir variabilidad horaria (entre 8:00 y 14:00, horario escolar)
+      const hourOffset = ((index * 3 + i * 7) % 6) * 60 * 60 * 1000;
+      const minuteOffset = ((index * 11 + i * 13) % 60) * 60 * 1000;
+      const baseTime = sessionStart.getTime() + hourOffset + minuteOffset;
+
+      // Ajustar timestamps de eventos relativos a esta base
+      const timeShift = baseTime - playData.events[0].timestamp.getTime();
       playData.events.forEach(e => {
         e.timestamp = new Date(e.timestamp.getTime() + timeShift);
       });
 
-      const completedAt = new Date(
-        playData.events[playData.events.length - 1].timestamp.getTime() + 1000
-      );
+      const startedAt = playData.events[0].timestamp;
+      const lastEventTime = playData.events[playData.events.length - 1].timestamp.getTime();
 
-      gamePlays.push({
+      const gamePlay = {
         sessionId: session._id,
         playerId: student._id,
         score: playData.score,
-        currentRound: numberOfRounds + 1,
+        currentRound: willAbandon ? playData.roundsPlayed : numberOfRounds + 1,
         events: playData.events,
         metrics: playData.metrics,
-        status: 'completed',
-        startedAt: playData.events[0].timestamp,
-        completedAt
-      });
+        status: willAbandon ? 'abandoned' : 'completed',
+        startedAt
+      };
+
+      if (!willAbandon) {
+        gamePlay.completedAt = new Date(lastEventTime + 1000);
+      }
+
+      gamePlays.push(gamePlay);
     }
   });
 
   return gamePlays;
 }
+
+// ══════════════════════════════════════════════════════════════════════
+// Agregación de métricas y ejecución
+// ══════════════════════════════════════════════════════════════════════
 
 function aggregateStudentMetrics(gamePlays) {
   const metricsByStudent = new Map();
@@ -292,22 +413,33 @@ function aggregateStudentMetrics(gamePlays) {
       bestScore: 0,
       totalCorrectAnswers: 0,
       totalErrors: 0,
+      totalTimeouts: 0,
+      totalAbandonedGames: 0,
       totalResponseTime: 0,
       totalResponses: 0,
       lastPlayedAt: null
     };
 
-    entry.totalGamesPlayed += 1;
-    entry.totalScore += play.score;
-    entry.bestScore = Math.max(entry.bestScore, play.score);
-    entry.totalCorrectAnswers += play.metrics.correctAttempts;
-    entry.totalErrors += play.metrics.errorAttempts;
-    const responses = play.metrics.correctAttempts + play.metrics.errorAttempts;
-    entry.totalResponses += responses;
-    entry.totalResponseTime += play.metrics.averageResponseTime * responses;
+    if (play.status === 'abandoned') {
+      // Las partidas abandonadas solo incrementan el contador de abandonos
+      entry.totalAbandonedGames += 1;
+    } else if (play.status === 'completed') {
+      // Las partidas completadas contribuyen a todas las métricas de rendimiento
+      entry.totalGamesPlayed += 1;
+      entry.totalScore += play.score;
+      entry.bestScore = Math.max(entry.bestScore, play.score);
+      entry.totalCorrectAnswers += play.metrics.correctAttempts;
+      entry.totalErrors += play.metrics.errorAttempts;
+      entry.totalTimeouts += play.metrics.timeoutAttempts;
+      const responses = play.metrics.correctAttempts + play.metrics.errorAttempts;
+      entry.totalResponses += responses;
+      entry.totalResponseTime += play.metrics.averageResponseTime * responses;
+    }
 
-    if (!entry.lastPlayedAt || play.completedAt > entry.lastPlayedAt) {
-      entry.lastPlayedAt = play.completedAt;
+    // lastPlayedAt se actualiza con cualquier partida (completada o abandonada)
+    const playDate = play.completedAt || play.startedAt;
+    if (playDate && (!entry.lastPlayedAt || playDate > entry.lastPlayedAt)) {
+      entry.lastPlayedAt = playDate;
     }
 
     metricsByStudent.set(studentId, entry);
@@ -321,11 +453,9 @@ async function recalculateSessionStatusesFromSeededPlays() {
     if (counters.activeOrPausedPlays > 0) {
       return 'active';
     }
-
     if (counters.totalPlays > 0) {
       return 'completed';
     }
-
     return 'created';
   };
 
@@ -369,7 +499,6 @@ async function recalculateSessionStatusesFromSeededPlays() {
     }
 
     applySessionStatus(session, nextStatus);
-
     await session.save();
   }
 }
@@ -407,6 +536,8 @@ async function seedGamePlays(sessions, students) {
               'studentMetrics.bestScore': metrics.bestScore,
               'studentMetrics.totalCorrectAnswers': metrics.totalCorrectAnswers,
               'studentMetrics.totalErrors': metrics.totalErrors,
+              'studentMetrics.totalTimeouts': metrics.totalTimeouts,
+              'studentMetrics.totalAbandonedGames': metrics.totalAbandonedGames,
               'studentMetrics.averageResponseTime': averageResponseTime,
               'studentMetrics.lastPlayedAt': metrics.lastPlayedAt
             }
@@ -418,14 +549,19 @@ async function seedGamePlays(sessions, students) {
     await Promise.all(updatePromises);
     await recalculateSessionStatusesFromSeededPlays();
 
-    // Contar por estado
+    // Estadísticas de lo generado
     const byStatus = gamePlays.reduce((acc, gp) => {
       acc[gp.status] = (acc[gp.status] || 0) + 1;
       return acc;
     }, {});
 
+    const uniqueStudents = new Set(gamePlays.map(gp => gp.playerId.toString())).size;
+    const uniqueSessions = new Set(gamePlays.map(gp => gp.sessionId.toString())).size;
+
     logger.info('Partidas (GamePlays) seeded exitosamente');
     logger.info(`- ${gamePlays.length} partidas totales`);
+    logger.info(`- ${uniqueStudents} estudiantes con partidas`);
+    logger.info(`- ${uniqueSessions} sesiones utilizadas`);
     Object.entries(byStatus).forEach(([status, count]) => {
       logger.info(`- ${count} partidas en estado "${status}"`);
     });

--- a/backend/src/controllers/analyticsAdvancedController.js
+++ b/backend/src/controllers/analyticsAdvancedController.js
@@ -1,0 +1,385 @@
+/**
+ * @fileoverview Controlador para endpoints de analytics avanzados (Sprint 5 expansion).
+ * Conecta los sub-servicios de analytics/ con las rutas HTTP.
+ *
+ * Separado de analyticsController.js para mantener zero regresión — ver ADR-026.
+ *
+ * @module controllers/analyticsAdvancedController
+ */
+
+const { sendSuccess } = require('../utils/responseHelper');
+const { cacheGet } = require('../utils/cacheHelper');
+const { ensureStudentBelongsToTeacher } = require('../utils/ownershipHelpers');
+const userRepository = require('../repositories/userRepository');
+
+// Sub-servicios de analytics
+const alertsService = require('../services/analytics/alertsService');
+const studentTrajectoryService = require('../services/analytics/studentTrajectoryService');
+const sessionAnalysisService = require('../services/analytics/sessionAnalysisService');
+const engagementService = require('../services/analytics/engagementService');
+const contentEffectivenessService = require('../services/analytics/contentEffectivenessService');
+const reportDataService = require('../services/analytics/reportDataService');
+
+// ══════════════════════════════════════════════════════════════════════
+// Alertas inteligentes (E15, E16)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene alertas activas para los alumnos del profesor.
+ * @route GET /api/analytics/alerts
+ */
+exports.getAlerts = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { severity, type, limit } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `alerts:${teacherId}:${severity || 'all'}:${type || 'all'}`,
+    async () => alertsService.getAlerts(teacherId, { severity, type, limit }),
+    600
+  );
+
+  sendSuccess(res, data);
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Trayectoria de aprendizaje (E01-E04)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene la trayectoria de aprendizaje de un estudiante.
+ * @route GET /api/analytics/student/:id/trajectory
+ */
+exports.getStudentTrajectory = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, granularity } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `trajectory:${id}:${timeRange}:${granularity || 'auto'}`,
+    async () => studentTrajectoryService.getStudentTrajectory(id, { timeRange, granularity }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Obtiene la velocidad de mejora del estudiante.
+ * @route GET /api/analytics/student/:id/velocity
+ */
+exports.getStudentVelocity = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, windowDays } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await studentTrajectoryService.getStudentVelocity(id, { timeRange, windowDays });
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Detecta periodos de estancamiento del estudiante.
+ * @route GET /api/analytics/student/:id/plateaus
+ */
+exports.getStudentPlateaus = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, minDays } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await studentTrajectoryService.getStudentPlateaus(id, { timeRange, minDays });
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Obtiene la evolución por contexto o mecánica.
+ * @route GET /api/analytics/student/:id/evolution
+ */
+exports.getStudentEvolution = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, groupBy } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await studentTrajectoryService.getStudentEvolution(id, { timeRange, groupBy });
+
+  sendSuccess(res, data);
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Análisis de sesiones (E05-E08)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Desglose ronda-a-ronda de una partida.
+ * @route GET /api/analytics/gameplay/:id/rounds
+ */
+exports.getGameplayRounds = async (req, res) => {
+  const { id } = req.params;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `rounds:${id}`,
+    async () => sessionAnalysisService.getGameplayRounds(id),
+    600
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Análisis de tarjetas a nivel de clase.
+ * @route GET /api/analytics/classroom/card-analysis
+ */
+exports.getCardAnalysis = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, contextId, limit } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `cardAnalysis:${teacherId}:${timeRange}:${contextId || 'all'}`,
+    async () => sessionAnalysisService.getCardAnalysis(teacherId, { timeRange, contextId, limit }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Momentos de dificultad de un estudiante.
+ * @route GET /api/analytics/student/:id/struggles
+ */
+exports.getStudentStruggles = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, minConsecutiveErrors } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await sessionAnalysisService.getStudentStruggles(id, {
+    timeRange,
+    minConsecutiveErrors
+  });
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Indicadores de fatiga de la clase.
+ * @route GET /api/analytics/classroom/fatigue
+ */
+exports.getClassroomFatigue = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `fatigue:${teacherId}:${timeRange}`,
+    async () => sessionAnalysisService.getClassroomFatigue(teacherId, { timeRange }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Engagement (E09-E11)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Engagement individual del estudiante.
+ * @route GET /api/analytics/student/:id/engagement
+ */
+exports.getStudentEngagement = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `engagement:${id}:${timeRange}`,
+    async () => engagementService.getStudentEngagement(id, { timeRange }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Engagement agregado de la clase.
+ * @route GET /api/analytics/classroom/engagement
+ */
+exports.getClassroomEngagement = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, sort, order } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `classEngagement:${teacherId}:${timeRange}:${sort}:${order}`,
+    async () => engagementService.getClassroomEngagement(teacherId, { timeRange, sort, order }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Patrones de juego del estudiante.
+ * @route GET /api/analytics/student/:id/play-patterns
+ */
+exports.getStudentPlayPatterns = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await engagementService.getStudentPlayPatterns(id, { timeRange });
+
+  sendSuccess(res, data);
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Efectividad de contenido (E12-E14)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Efectividad de contextos/mecánicas.
+ * @route GET /api/analytics/classroom/content-effectiveness
+ */
+exports.getContentEffectiveness = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, groupBy } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `contentEffectiveness:${teacherId}:${timeRange}:${groupBy}`,
+    async () =>
+      contentEffectivenessService.getContentEffectiveness(teacherId, { timeRange, groupBy }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Tarjetas con dificultad alta.
+ * @route GET /api/analytics/classroom/card-difficulty
+ */
+exports.getCardDifficulty = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, contextId, threshold } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `cardDifficulty:${teacherId}:${timeRange}:${contextId || 'all'}:${threshold}`,
+    async () =>
+      contentEffectivenessService.getCardDifficulty(teacherId, {
+        timeRange,
+        contextId,
+        threshold
+      }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Curvas de aprendizaje por contenido.
+ * @route GET /api/analytics/classroom/learning-curves
+ */
+exports.getLearningCurves = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, contextId, mechanicId } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `learningCurves:${teacherId}:${timeRange}:${contextId || 'all'}:${mechanicId || 'all'}`,
+    async () =>
+      contentEffectivenessService.getLearningCurves(teacherId, {
+        timeRange,
+        contextId,
+        mechanicId
+      }),
+    300
+  );
+
+  sendSuccess(res, data);
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Reportes y exportación (E17-E19)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Reporte completo de un estudiante.
+ * @route GET /api/analytics/reports/student/:id
+ */
+exports.getStudentReport = async (req, res) => {
+  const { id } = req.params;
+  const { timeRange, format } = req.query;
+
+  await ensureStudentBelongsToTeacher(id, req.user, userRepository);
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `report:student:${id}:${timeRange}:${format}`,
+    async () => reportDataService.getStudentReport(id, { timeRange, format }),
+    600
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Reporte completo de la clase.
+ * @route GET /api/analytics/reports/classroom
+ */
+exports.getClassroomReport = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange, format } = req.query;
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `report:classroom:${teacherId}:${timeRange}:${format}`,
+    async () => reportDataService.getClassroomReport(teacherId, { timeRange, format }),
+    600
+  );
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Datos tabulares para exportación CSV.
+ * @route GET /api/analytics/reports/classroom/export
+ */
+exports.getClassroomExport = async (req, res) => {
+  const teacherId = req.user._id.toString();
+  const { timeRange } = req.query;
+
+  const data = await reportDataService.getClassroomExport(teacherId, { timeRange });
+
+  sendSuccess(res, data);
+};
+
+/**
+ * Obtiene resumen de alertas (conteos por severidad y tipo).
+ * @route GET /api/analytics/alerts/summary
+ */
+exports.getAlertsSummary = async (req, res) => {
+  const teacherId = req.user._id.toString();
+
+  const data = await cacheGet(
+    'cache:analytics',
+    `alertsSummary:${teacherId}`,
+    async () => alertsService.getAlertsSummary(teacherId),
+    600
+  );
+
+  sendSuccess(res, data);
+};

--- a/backend/src/controllers/analyticsController.js
+++ b/backend/src/controllers/analyticsController.js
@@ -5,6 +5,8 @@
 
 const analyticsService = require('../services/analyticsService');
 const userRepository = require('../repositories/userRepository');
+const GameSession = require('../models/GameSession');
+const GamePlay = require('../models/GamePlay');
 const { sendSuccess } = require('../utils/responseHelper');
 const { cacheGet } = require('../utils/cacheHelper');
 const { ensureStudentBelongsToTeacher } = require('../utils/ownershipHelpers');
@@ -89,7 +91,7 @@ exports.getClassroomDifficulties = async (req, res) => {
  */
 exports.getClassroomStudents = async (req, res) => {
   const teacherId = req.user._id.toString();
-  const { sort, order, tier, classroom } = req.query;
+  const { sort, order, tier, classroom, contextId, mechanicId } = req.query;
 
   const data = await analyticsService.getClassroomStudents(teacherId, {
     sort,
@@ -97,6 +99,35 @@ exports.getClassroomStudents = async (req, res) => {
     tier,
     classroom
   });
+
+  // Filtro opcional por contexto/mecánica: identifica los estudiantes que han
+  // jugado en sesiones con el contexto o mecánica seleccionados y descarta el resto.
+  // No modifica analyticsService.js (ADR-026) — filtra a nivel de controlador.
+  if (contextId || mechanicId) {
+    const sessionFilter = { createdBy: req.user._id };
+    if (contextId) {
+      sessionFilter.contextId = contextId;
+    }
+    if (mechanicId) {
+      sessionFilter.mechanicId = mechanicId;
+    }
+
+    const sessionIds = await GameSession.find(sessionFilter).select('_id').lean();
+    const matchingSessionIds = sessionIds.map(s => s._id);
+
+    if (matchingSessionIds.length === 0) {
+      data.students = [];
+    } else {
+      const playerIds = await GamePlay.distinct('playerId', {
+        sessionId: { $in: matchingSessionIds },
+        status: 'completed'
+      });
+      const playerIdSet = new Set(playerIds.map(id => id.toString()));
+      data.students = data.students.filter(s => playerIdSet.has(s._id.toString()));
+    }
+
+    data.total = data.students.length;
+  }
 
   sendSuccess(res, data);
 };

--- a/backend/src/models/GamePlay.js
+++ b/backend/src/models/GamePlay.js
@@ -334,4 +334,11 @@ gamePlaySchema.index({ playerId: 1, completedAt: -1 });
  */
 gamePlaySchema.index({ status: 1, completedAt: -1 });
 
+/**
+ * Índice compuesto para analytics de engagement: queries que necesitan
+ * partidas abandonadas y completadas de un jugador ordenadas por fecha.
+ * Caso de uso: engagement score, análisis de abandono (E09, E10).
+ */
+gamePlaySchema.index({ playerId: 1, status: 1, startedAt: -1 });
+
 module.exports = mongoose.model('GamePlay', gamePlaySchema);

--- a/backend/src/models/GamePlay.js
+++ b/backend/src/models/GamePlay.js
@@ -341,4 +341,11 @@ gamePlaySchema.index({ status: 1, completedAt: -1 });
  */
 gamePlaySchema.index({ playerId: 1, status: 1, startedAt: -1 });
 
+/**
+ * Índice compuesto para analytics de sesión: queries que filtran partidas
+ * por sesión, estado y fecha de completado.
+ * Caso de uso: análisis de rondas, tarjetas, fatiga (E05-E08).
+ */
+gamePlaySchema.index({ sessionId: 1, status: 1, completedAt: -1 });
+
 module.exports = mongoose.model('GamePlay', gamePlaySchema);

--- a/backend/src/models/GameSession.js
+++ b/backend/src/models/GameSession.js
@@ -368,6 +368,12 @@ gameSessionSchema.index({ createdBy: 1, createdAt: -1 });
  */
 gameSessionSchema.index({ createdBy: 1, status: 1 });
 
+/**
+ * Índice compuesto para lookups de contenido por profesor y contexto.
+ * Caso de uso: análisis de tarjetas, efectividad de contenido (E06, E12-E14).
+ */
+gameSessionSchema.index({ createdBy: 1, contextId: 1 });
+
 const GameSession = mongoose.model('GameSession', gameSessionSchema);
 
 // Exportar modelo y función auxiliar

--- a/backend/src/models/GameSession.js
+++ b/backend/src/models/GameSession.js
@@ -374,6 +374,12 @@ gameSessionSchema.index({ createdBy: 1, status: 1 });
  */
 gameSessionSchema.index({ createdBy: 1, contextId: 1 });
 
+/**
+ * Índice compuesto para lookups de analytics por profesor y mecánica.
+ * Caso de uso: efectividad de contenido, fatiga, engagement (E06, E08, E12-E14).
+ */
+gameSessionSchema.index({ createdBy: 1, mechanicId: 1 });
+
 const GameSession = mongoose.model('GameSession', gameSessionSchema);
 
 // Exportar modelo y función auxiliar

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -189,6 +189,16 @@ const userSchema = new mongoose.Schema(
         default: 0,
         min: 0
       },
+      totalTimeouts: {
+        type: Number,
+        default: 0,
+        min: 0
+      },
+      totalAbandonedGames: {
+        type: Number,
+        default: 0,
+        min: 0
+      },
       lastPlayedAt: Date
     },
     status: {
@@ -281,6 +291,7 @@ userSchema.methods.updateLastLogin = function () {
  * @param {number} playResults.score - Puntuación obtenida en la partida
  * @param {number} playResults.correctAttempts - Cantidad de respuestas correctas
  * @param {number} playResults.errorAttempts - Cantidad de errores
+ * @param {number} [playResults.timeoutAttempts=0] - Cantidad de timeouts
  * @param {number} playResults.averageResponseTime - Tiempo medio de respuesta en ms
  * @returns {Promise<User>} Promesa que resuelve con el documento actualizado
  * @example
@@ -288,6 +299,7 @@ userSchema.methods.updateLastLogin = function () {
  *   score: 50,
  *   correctAttempts: 8,
  *   errorAttempts: 2,
+ *   timeoutAttempts: 1,
  *   averageResponseTime: 3500
  * });
  */
@@ -311,9 +323,10 @@ userSchema.methods.updateStudentMetrics = function (playResults) {
     this.studentMetrics.bestScore = playResults.score;
   }
 
-  // Actualizar contadores de aciertos y errores
+  // Actualizar contadores de aciertos, errores y timeouts
   this.studentMetrics.totalCorrectAnswers += playResults.correctAttempts;
   this.studentMetrics.totalErrors += playResults.errorAttempts;
+  this.studentMetrics.totalTimeouts += playResults.timeoutAttempts || 0;
 
   // Recalcular tiempo medio de respuesta (promedio ponderado)
   const totalAttempts = this.studentMetrics.totalCorrectAnswers + this.studentMetrics.totalErrors;
@@ -328,6 +341,26 @@ userSchema.methods.updateStudentMetrics = function (playResults) {
   }
 
   // Actualizar última fecha de juego
+  this.studentMetrics.lastPlayedAt = new Date();
+
+  return this.save();
+};
+
+/**
+ * Registra una partida abandonada en las métricas del alumno.
+ * No afecta al averageScore (las abandonadas no cuentan para la media).
+ * Solo incrementa el contador de abandonos y actualiza lastPlayedAt.
+ *
+ * @instance
+ * @memberof User
+ * @returns {Promise<User>} Promesa que resuelve con el documento actualizado
+ */
+userSchema.methods.recordAbandonedGame = function () {
+  if (this.role !== 'student') {
+    throw new Error('Solo los alumnos tienen métricas de juego');
+  }
+
+  this.studentMetrics.totalAbandonedGames += 1;
   this.studentMetrics.lastPlayedAt = new Date();
 
   return this.save();

--- a/backend/src/repositories/gameSessionRepository.js
+++ b/backend/src/repositories/gameSessionRepository.js
@@ -33,6 +33,8 @@ const deleteById = id => baseRepo.deleteById(GameSession, id);
 
 const deleteMany = filter => baseRepo.deleteMany(GameSession, filter);
 
+const aggregate = pipeline => GameSession.aggregate(pipeline);
+
 module.exports = {
   find,
   findById,
@@ -44,5 +46,6 @@ module.exports = {
   updateOne,
   findByIdAndUpdate,
   deleteById,
-  deleteMany
+  deleteMany,
+  aggregate
 };

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -18,9 +18,28 @@ const {
   classroomTrendsQuerySchema,
   studentSummaryQuerySchema,
   classroomHeatmapQuerySchema,
-  classroomRankingsQuerySchema
+  classroomRankingsQuerySchema,
+  // Schemas avanzados (Analytics Expansion)
+  trajectoryQuerySchema,
+  velocityQuerySchema,
+  plateauQuerySchema,
+  evolutionQuerySchema,
+  gameplayParamsSchema,
+  cardAnalysisQuerySchema,
+  strugglesQuerySchema,
+  fatigueQuerySchema,
+  engagementQuerySchema,
+  classroomEngagementQuerySchema,
+  playPatternsQuerySchema,
+  contentEffectivenessQuerySchema,
+  cardDifficultyQuerySchema,
+  learningCurvesQuerySchema,
+  alertsQuerySchema,
+  reportQuerySchema,
+  reportExportQuerySchema
 } = require('../validators/analyticsValidator');
 const asyncHandler = require('../utils/asyncHandler');
+const analyticsAdvancedController = require('../controllers/analyticsAdvancedController');
 
 // Todas las rutas requieren estar autenticado como profesor o super admin
 router.use(authenticate, requireRole('teacher', 'super_admin'), analyticsRateLimiter);
@@ -125,6 +144,237 @@ router.get(
   validateParams(analyticsStudentParamsSchema),
   validateQuery(studentSummaryQuerySchema),
   asyncHandler(analyticsController.getStudentSummary)
+);
+
+// ──────────────── Rutas avanzadas (Analytics Expansion) ────────────────
+
+// — Trayectoria de aprendizaje (E01-E04) —
+
+/**
+ * @route   GET /api/analytics/student/:id/trajectory
+ * @desc    Progresión temporal con tendencia calculada (E01)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/trajectory',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(trajectoryQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentTrajectory)
+);
+
+/**
+ * @route   GET /api/analytics/student/:id/velocity
+ * @desc    Velocidad de mejora en ventanas temporales (E02)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/velocity',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(velocityQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentVelocity)
+);
+
+/**
+ * @route   GET /api/analytics/student/:id/plateaus
+ * @desc    Detección de periodos de estancamiento (E03)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/plateaus',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(plateauQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentPlateaus)
+);
+
+/**
+ * @route   GET /api/analytics/student/:id/evolution
+ * @desc    Evolución por contexto o mecánica (E04)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/evolution',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(evolutionQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentEvolution)
+);
+
+// — Análisis de sesiones (E05-E08) —
+
+/**
+ * @route   GET /api/analytics/gameplay/:id/rounds
+ * @desc    Desglose ronda-a-ronda de una partida con detección de fatiga (E05)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/gameplay/:id/rounds',
+  validateParams(gameplayParamsSchema),
+  asyncHandler(analyticsAdvancedController.getGameplayRounds)
+);
+
+/**
+ * @route   GET /api/analytics/classroom/card-analysis
+ * @desc    Análisis de rendimiento por tarjeta RFID (E06)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/card-analysis',
+  validateQuery(cardAnalysisQuerySchema),
+  asyncHandler(analyticsAdvancedController.getCardAnalysis)
+);
+
+/**
+ * @route   GET /api/analytics/student/:id/struggles
+ * @desc    Momentos de dificultad — errores consecutivos (E07)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/struggles',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(strugglesQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentStruggles)
+);
+
+/**
+ * @route   GET /api/analytics/classroom/fatigue
+ * @desc    Indicadores de fatiga agregados de la clase (E08)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/fatigue',
+  validateQuery(fatigueQuerySchema),
+  asyncHandler(analyticsAdvancedController.getClassroomFatigue)
+);
+
+// — Engagement (E09-E11) —
+
+/**
+ * @route   GET /api/analytics/student/:id/engagement
+ * @desc    Engagement score individual con componentes desglosados (E09)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/engagement',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(engagementQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentEngagement)
+);
+
+/**
+ * @route   GET /api/analytics/classroom/engagement
+ * @desc    Engagement agregado de toda la clase (E10)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/engagement',
+  validateQuery(classroomEngagementQuerySchema),
+  asyncHandler(analyticsAdvancedController.getClassroomEngagement)
+);
+
+/**
+ * @route   GET /api/analytics/student/:id/play-patterns
+ * @desc    Patrones de juego del estudiante (E11)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/student/:id/play-patterns',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(playPatternsQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentPlayPatterns)
+);
+
+// — Efectividad de contenido (E12-E14) —
+
+/**
+ * @route   GET /api/analytics/classroom/content-effectiveness
+ * @desc    Qué contextos/mecánicas producen mejor aprendizaje (E12)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/content-effectiveness',
+  validateQuery(contentEffectivenessQuerySchema),
+  asyncHandler(analyticsAdvancedController.getContentEffectiveness)
+);
+
+/**
+ * @route   GET /api/analytics/classroom/card-difficulty
+ * @desc    Tarjetas problemáticas con tasa de error alta (E13)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/card-difficulty',
+  validateQuery(cardDifficultyQuerySchema),
+  asyncHandler(analyticsAdvancedController.getCardDifficulty)
+);
+
+/**
+ * @route   GET /api/analytics/classroom/learning-curves
+ * @desc    Curvas de aprendizaje por contenido (E14)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/classroom/learning-curves',
+  validateQuery(learningCurvesQuerySchema),
+  asyncHandler(analyticsAdvancedController.getLearningCurves)
+);
+
+// — Alertas inteligentes (E15-E16) —
+
+/**
+ * @route   GET /api/analytics/alerts
+ * @desc    Alertas inteligentes computadas server-side (E15)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/alerts',
+  validateQuery(alertsQuerySchema),
+  asyncHandler(analyticsAdvancedController.getAlerts)
+);
+
+/**
+ * @route   GET /api/analytics/alerts/summary
+ * @desc    Resumen de alertas (conteos) para badges del sidebar (E16)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/alerts/summary',
+  validateQuery(emptyObjectSchema),
+  asyncHandler(analyticsAdvancedController.getAlertsSummary)
+);
+
+// — Reportes y exportación (E17-E19) —
+
+/**
+ * @route   GET /api/analytics/reports/student/:id
+ * @desc    Datos completos de reporte de un estudiante (E17)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/reports/student/:id',
+  validateParams(analyticsStudentParamsSchema),
+  validateQuery(reportQuerySchema),
+  asyncHandler(analyticsAdvancedController.getStudentReport)
+);
+
+/**
+ * @route   GET /api/analytics/reports/classroom
+ * @desc    Datos completos de reporte de la clase (E18)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/reports/classroom',
+  validateQuery(reportQuerySchema),
+  asyncHandler(analyticsAdvancedController.getClassroomReport)
+);
+
+/**
+ * @route   GET /api/analytics/reports/classroom/export
+ * @desc    Datos tabulares optimizados para CSV (E19)
+ * @access  Private (Teacher/Super Admin)
+ */
+router.get(
+  '/reports/classroom/export',
+  validateQuery(reportExportQuerySchema),
+  asyncHandler(analyticsAdvancedController.getClassroomExport)
 );
 
 module.exports = router;

--- a/backend/src/services/analytics/alertsService.js
+++ b/backend/src/services/analytics/alertsService.js
@@ -1,0 +1,618 @@
+/**
+ * @fileoverview Servicio de alertas inteligentes para analytics.
+ * Computa alertas on-the-fly basándose en patrones detectados en los datos
+ * de GamePlay y User.studentMetrics.
+ *
+ * Las alertas NO se almacenan en BD — se derivan de datos existentes con cache.
+ * Ver Analytics_Design_Rationale.md § 2.5 para justificación de umbrales.
+ *
+ * @module services/analytics/alertsService
+ */
+
+const gamePlayRepository = require('../../repositories/gamePlayRepository');
+const userRepository = require('../../repositories/userRepository');
+const logger = require('../../utils/logger').child({ component: 'alertsService' });
+const {
+  ALERT_TYPES,
+  toObjectId,
+  getStartDate,
+  getPeriodDates,
+  generateAlertId
+} = require('./analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// Detectores individuales de alertas
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Detecta alumnos con rendimiento en descenso.
+ * Compara score promedio del periodo actual vs periodo anterior.
+ *
+ * @param {string} teacherId
+ * @param {Array} students - Lista de estudiantes del profesor
+ * @returns {Promise<Array>} Alertas de tipo declining_performance
+ */
+async function detectDecliningPerformance(teacherId, students) {
+  const alerts = [];
+  const { currentStart, previousStart, now } = getPeriodDates('7d');
+
+  const studentIds = students.map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return alerts;
+  }
+
+  // Obtener scores promedio por estudiante en ambos periodos con un solo pipeline
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        status: 'completed',
+        completedAt: { $gte: previousStart, $lte: now }
+      }
+    },
+    {
+      $addFields: {
+        period: {
+          $cond: [{ $gte: ['$completedAt', currentStart] }, 'current', 'previous']
+        }
+      }
+    },
+    {
+      $group: {
+        _id: { playerId: '$playerId', period: '$period' },
+        avgScore: { $avg: '$score' },
+        count: { $sum: 1 }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+
+  // Agrupar por estudiante
+  const byStudent = {};
+  for (const r of results) {
+    const sid = r._id.playerId.toString();
+    if (!byStudent[sid]) {
+      byStudent[sid] = {};
+    }
+    byStudent[sid][r._id.period] = { avgScore: r.avgScore, count: r.count };
+  }
+
+  for (const student of students) {
+    const sid = student._id.toString();
+    const data = byStudent[sid];
+    if (!data?.current || !data?.previous) {
+      continue;
+    }
+    if (data.previous.count < 2 || data.current.count < 2) {
+      continue;
+    }
+
+    const declinePercent =
+      ((data.previous.avgScore - data.current.avgScore) / data.previous.avgScore) * 100;
+
+    if (declinePercent > ALERT_TYPES.declining_performance.thresholds.warning) {
+      const severity =
+        declinePercent > ALERT_TYPES.declining_performance.thresholds.critical
+          ? 'critical'
+          : 'warning';
+
+      alerts.push({
+        id: generateAlertId('declining_performance', sid),
+        type: 'declining_performance',
+        severity,
+        studentId: sid,
+        studentName: student.name,
+        message: `El rendimiento de ${student.name} ha bajado un ${Math.round(declinePercent)}% en la última semana`,
+        recommendation:
+          'Considerar revisar el contenido asignado o proporcionar sesiones de refuerzo',
+        detectedAt: new Date().toISOString(),
+        data: {
+          previousAvg: Math.round(data.previous.avgScore),
+          currentAvg: Math.round(data.current.avgScore),
+          declinePercent: Math.round(declinePercent * 10) / 10
+        }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Detecta alumnos inactivos (sin jugar en >7 días).
+ *
+ * @param {Array} students - Lista de estudiantes con studentMetrics
+ * @returns {Array} Alertas de tipo inactivity
+ */
+function detectInactivity(students) {
+  const alerts = [];
+  const now = new Date();
+
+  for (const student of students) {
+    const lastPlayed = student.studentMetrics?.lastPlayedAt;
+    if (!lastPlayed) {
+      continue;
+    }
+
+    const daysSince = Math.floor((now - new Date(lastPlayed)) / (1000 * 60 * 60 * 24));
+
+    if (daysSince >= ALERT_TYPES.inactivity.thresholds.info) {
+      const severity = daysSince >= ALERT_TYPES.inactivity.thresholds.warning ? 'warning' : 'info';
+
+      alerts.push({
+        id: generateAlertId('inactivity', student._id.toString()),
+        type: 'inactivity',
+        severity,
+        studentId: student._id.toString(),
+        studentName: student.name,
+        message: `${student.name} no ha jugado en ${daysSince} días`,
+        recommendation:
+          daysSince >= 14
+            ? 'Verificar si el alumno tiene algún problema para acceder a las sesiones'
+            : 'Considerar asignar una sesión de juego motivadora',
+        detectedAt: new Date().toISOString(),
+        data: { daysSinceLastPlay: daysSince, lastPlayedAt: lastPlayed }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Detecta caídas repentinas de puntuación en una partida individual.
+ * Se activa cuando un score está >30 puntos por debajo de la media del alumno.
+ *
+ * @param {string} teacherId
+ * @param {Array} students
+ * @returns {Promise<Array>} Alertas de tipo sudden_score_drop
+ */
+async function detectSuddenScoreDrop(teacherId, students) {
+  const alerts = [];
+  const threshold = ALERT_TYPES.sudden_score_drop.thresholds.warning;
+  const sevenDaysAgo = getStartDate('7d');
+
+  const studentIds = students
+    .filter(s => s.studentMetrics?.averageScore > 0)
+    .map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return alerts;
+  }
+
+  // Buscar partidas recientes con score muy bajo respecto a la media
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        status: 'completed',
+        completedAt: { $gte: sevenDaysAgo }
+      }
+    },
+    { $sort: { completedAt: -1 } },
+    {
+      $group: {
+        _id: '$playerId',
+        lastGame: { $first: '$$ROOT' }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+  const studentMap = new Map(students.map(s => [s._id.toString(), s]));
+
+  for (const r of results) {
+    const sid = r._id.toString();
+    const student = studentMap.get(sid);
+    if (!student) {
+      continue;
+    }
+
+    const avgScore = student.studentMetrics.averageScore;
+    const lastScore = r.lastGame.score;
+    const drop = avgScore - lastScore;
+
+    if (drop > threshold) {
+      alerts.push({
+        id: generateAlertId('sudden_score_drop', sid),
+        type: 'sudden_score_drop',
+        severity: 'warning',
+        studentId: sid,
+        studentName: student.name,
+        message: `${student.name} obtuvo ${lastScore} puntos en su última partida (media: ${Math.round(avgScore)})`,
+        recommendation: 'Revisar si hubo alguna dificultad específica en la última sesión',
+        detectedAt: new Date().toISOString(),
+        data: {
+          lastScore,
+          averageScore: Math.round(avgScore),
+          dropPoints: Math.round(drop)
+        }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Detecta alumnos con tasa de timeout consistentemente alta.
+ * Timeout >30% en las últimas 5 partidas indica confusión sistemática.
+ *
+ * @param {string} teacherId
+ * @param {Array} students
+ * @returns {Promise<Array>} Alertas de tipo consistent_timeout
+ */
+async function detectConsistentTimeout(teacherId, students) {
+  const alerts = [];
+  const threshold = ALERT_TYPES.consistent_timeout.thresholds.warning;
+
+  const studentIds = students.map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return alerts;
+  }
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        status: 'completed',
+        'metrics.totalAttempts': { $gt: 0 }
+      }
+    },
+    { $sort: { completedAt: -1 } },
+    {
+      $group: {
+        _id: '$playerId',
+        recentGames: {
+          $push: {
+            timeoutRate: {
+              $cond: [
+                { $gt: ['$metrics.totalAttempts', 0] },
+                { $divide: ['$metrics.timeoutAttempts', '$metrics.totalAttempts'] },
+                0
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
+      $project: {
+        last5: { $slice: ['$recentGames', 5] }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+  const studentMap = new Map(students.map(s => [s._id.toString(), s]));
+
+  for (const r of results) {
+    if (r.last5.length < 3) {
+      continue;
+    }
+
+    const avgTimeoutRate = r.last5.reduce((sum, g) => sum + g.timeoutRate, 0) / r.last5.length;
+
+    if (avgTimeoutRate > threshold) {
+      const sid = r._id.toString();
+      const student = studentMap.get(sid);
+      if (!student) {
+        continue;
+      }
+
+      alerts.push({
+        id: generateAlertId('consistent_timeout', sid),
+        type: 'consistent_timeout',
+        severity: 'warning',
+        studentId: sid,
+        studentName: student.name,
+        message: `${student.name} tiene una tasa de timeout del ${Math.round(avgTimeoutRate * 100)}% en sus últimas ${r.last5.length} partidas`,
+        recommendation:
+          'Verificar si el tiempo límite es adecuado o si el alumno necesita apoyo adicional',
+        detectedAt: new Date().toISOString(),
+        data: {
+          avgTimeoutRate: Math.round(avgTimeoutRate * 100 * 10) / 10,
+          gamesAnalyzed: r.last5.length
+        }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Detecta alumnos con mejora rápida (>15% en 7 días).
+ * Alerta positiva para refuerzo.
+ *
+ * @param {string} teacherId
+ * @param {Array} students
+ * @returns {Promise<Array>} Alertas de tipo improving_fast
+ */
+async function detectImprovingFast(teacherId, students) {
+  const alerts = [];
+  const { currentStart, previousStart, now } = getPeriodDates('7d');
+  const threshold = ALERT_TYPES.improving_fast.thresholds.info;
+
+  const studentIds = students.map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return alerts;
+  }
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        status: 'completed',
+        completedAt: { $gte: previousStart, $lte: now }
+      }
+    },
+    {
+      $addFields: {
+        period: {
+          $cond: [{ $gte: ['$completedAt', currentStart] }, 'current', 'previous']
+        }
+      }
+    },
+    {
+      $group: {
+        _id: { playerId: '$playerId', period: '$period' },
+        avgScore: { $avg: '$score' },
+        count: { $sum: 1 }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+
+  const byStudent = {};
+  for (const r of results) {
+    const sid = r._id.playerId.toString();
+    if (!byStudent[sid]) {
+      byStudent[sid] = {};
+    }
+    byStudent[sid][r._id.period] = { avgScore: r.avgScore, count: r.count };
+  }
+
+  const studentMap = new Map(students.map(s => [s._id.toString(), s]));
+
+  for (const [sid, data] of Object.entries(byStudent)) {
+    if (!data.current || !data.previous) {
+      continue;
+    }
+    if (data.previous.count < 2 || data.current.count < 2) {
+      continue;
+    }
+    if (data.previous.avgScore === 0) {
+      continue;
+    }
+
+    const improvementPercent =
+      ((data.current.avgScore - data.previous.avgScore) / data.previous.avgScore) * 100;
+
+    if (improvementPercent > threshold) {
+      const student = studentMap.get(sid);
+      if (!student) {
+        continue;
+      }
+
+      alerts.push({
+        id: generateAlertId('improving_fast', sid),
+        type: 'improving_fast',
+        severity: 'info',
+        studentId: sid,
+        studentName: student.name,
+        message: `${student.name} ha mejorado un ${Math.round(improvementPercent)}% en la última semana`,
+        recommendation: 'Reforzar positivamente el progreso del alumno',
+        detectedAt: new Date().toISOString(),
+        data: {
+          previousAvg: Math.round(data.previous.avgScore),
+          currentAvg: Math.round(data.current.avgScore),
+          improvementPercent: Math.round(improvementPercent * 10) / 10
+        }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Detecta alumnos con alta tasa de abandono (>25% en 7 días).
+ *
+ * @param {string} teacherId
+ * @param {Array} students
+ * @returns {Promise<Array>} Alertas de tipo high_abandonment
+ */
+async function detectHighAbandonment(teacherId, students) {
+  const alerts = [];
+  const threshold = ALERT_TYPES.high_abandonment.thresholds.warning;
+  const sevenDaysAgo = getStartDate('7d');
+
+  const studentIds = students.map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return alerts;
+  }
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        startedAt: { $gte: sevenDaysAgo },
+        status: { $in: ['completed', 'abandoned'] }
+      }
+    },
+    {
+      $group: {
+        _id: '$playerId',
+        total: { $sum: 1 },
+        abandoned: {
+          $sum: { $cond: [{ $eq: ['$status', 'abandoned'] }, 1, 0] }
+        }
+      }
+    },
+    {
+      $match: { total: { $gte: 3 } }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+  const studentMap = new Map(students.map(s => [s._id.toString(), s]));
+
+  for (const r of results) {
+    const abandonmentRate = r.abandoned / r.total;
+
+    if (abandonmentRate > threshold) {
+      const sid = r._id.toString();
+      const student = studentMap.get(sid);
+      if (!student) {
+        continue;
+      }
+
+      alerts.push({
+        id: generateAlertId('high_abandonment', sid),
+        type: 'high_abandonment',
+        severity: 'warning',
+        studentId: sid,
+        studentName: student.name,
+        message: `${student.name} ha abandonado ${r.abandoned} de ${r.total} partidas en los últimos 7 días (${Math.round(abandonmentRate * 100)}%)`,
+        recommendation:
+          'Revisar si las sesiones son demasiado largas o si el contenido genera frustración',
+        detectedAt: new Date().toISOString(),
+        data: {
+          abandonedGames: r.abandoned,
+          totalGames: r.total,
+          abandonmentRate: Math.round(abandonmentRate * 100 * 10) / 10
+        }
+      });
+    }
+  }
+
+  return alerts;
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Funciones públicas
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene todas las alertas activas para los alumnos de un profesor.
+ * Ejecuta todos los detectores en paralelo y combina los resultados.
+ *
+ * @param {string} teacherId - ID del profesor
+ * @param {Object} [options] - Opciones de filtrado
+ * @param {string} [options.severity] - Filtrar por severidad
+ * @param {string} [options.type] - Filtrar por tipo de alerta
+ * @param {number} [options.limit=20] - Máximo de alertas a retornar
+ * @returns {Promise<Object>} { alerts, summary }
+ */
+async function getAlerts(teacherId, { severity, type, limit = 20 } = {}) {
+  // Obtener todos los estudiantes del profesor (con métricas)
+  const students = await userRepository.find(
+    {
+      createdBy: toObjectId(teacherId),
+      role: 'student',
+      status: 'active'
+    },
+    { select: 'name studentMetrics profile.classroom' }
+  );
+
+  if (students.length === 0) {
+    return {
+      alerts: [],
+      summary: { critical: 0, warning: 0, info: 0, total: 0 }
+    };
+  }
+
+  // Ejecutar todos los detectores en paralelo
+  const [
+    decliningAlerts,
+    inactivityAlerts,
+    scoreDropAlerts,
+    timeoutAlerts,
+    improvingAlerts,
+    abandonmentAlerts
+  ] = await Promise.all([
+    detectDecliningPerformance(teacherId, students),
+    Promise.resolve(detectInactivity(students)),
+    detectSuddenScoreDrop(teacherId, students),
+    detectConsistentTimeout(teacherId, students),
+    detectImprovingFast(teacherId, students),
+    detectHighAbandonment(teacherId, students)
+  ]);
+
+  let allAlerts = [
+    ...decliningAlerts,
+    ...inactivityAlerts,
+    ...scoreDropAlerts,
+    ...timeoutAlerts,
+    ...improvingAlerts,
+    ...abandonmentAlerts
+  ];
+
+  // Filtrar por severidad si se especifica
+  if (severity) {
+    allAlerts = allAlerts.filter(a => a.severity === severity);
+  }
+
+  // Filtrar por tipo si se especifica
+  if (type) {
+    allAlerts = allAlerts.filter(a => a.type === type);
+  }
+
+  // Ordenar: critical primero, luego warning, luego info
+  const severityOrder = { critical: 0, warning: 1, info: 2 };
+  allAlerts.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+  // Calcular summary antes de aplicar limit
+  const summary = {
+    critical: allAlerts.filter(a => a.severity === 'critical').length,
+    warning: allAlerts.filter(a => a.severity === 'warning').length,
+    info: allAlerts.filter(a => a.severity === 'info').length,
+    total: allAlerts.length
+  };
+
+  // Aplicar limit
+  const limitedAlerts = allAlerts.slice(0, limit);
+
+  logger.info('Alertas computadas', {
+    teacherId,
+    total: summary.total,
+    critical: summary.critical,
+    warning: summary.warning,
+    info: summary.info
+  });
+
+  return { alerts: limitedAlerts, summary };
+}
+
+/**
+ * Obtiene solo el resumen de alertas (conteo por severidad y tipo).
+ * Versión ligera para badges y contadores del sidebar.
+ *
+ * @param {string} teacherId - ID del profesor
+ * @returns {Promise<Object>} { total, bySeverity, byType }
+ */
+async function getAlertsSummary(teacherId) {
+  const { alerts } = await getAlerts(teacherId, { limit: 100 });
+
+  const byType = {};
+  for (const alert of alerts) {
+    byType[alert.type] = (byType[alert.type] || 0) + 1;
+  }
+
+  return {
+    total: alerts.length,
+    bySeverity: {
+      critical: alerts.filter(a => a.severity === 'critical').length,
+      warning: alerts.filter(a => a.severity === 'warning').length,
+      info: alerts.filter(a => a.severity === 'info').length
+    },
+    byType
+  };
+}
+
+module.exports = {
+  getAlerts,
+  getAlertsSummary
+};

--- a/backend/src/services/analytics/analyticsHelpers.js
+++ b/backend/src/services/analytics/analyticsHelpers.js
@@ -1,0 +1,681 @@
+/**
+ * @fileoverview Utilidades compartidas para los sub-servicios de analytics avanzados.
+ * Proporciona constantes, funciones de clasificación y helpers de fechas
+ * reutilizados por todos los sub-servicios de analytics/.
+ *
+ * NOTA: Las funciones idénticas (PERFORMANCE_TIERS, classifyTier, calcAccuracyRate)
+ * también existen en analyticsService.js (servicio original). No se refactorizan
+ * allí para mantener zero regresión — ver ADR-026.
+ *
+ * @module services/analytics/analyticsHelpers
+ */
+
+const mongoose = require('mongoose');
+
+// ══════════════════════════════════════════════════════════════════════
+// Constantes de clasificación
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Rangos de rendimiento para clasificación de estudiantes.
+ * Coinciden con los definidos en analyticsService.js (ADR-017).
+ */
+const PERFORMANCE_TIERS = [
+  { tier: 'risk', label: 'Riesgo (0-49)', min: 0, max: 49 },
+  { tier: 'average', label: 'Promedio (50-69)', min: 50, max: 69 },
+  { tier: 'good', label: 'Bueno (70-89)', min: 70, max: 89 },
+  { tier: 'excellent', label: 'Excelente (90-100)', min: 90, max: 100 }
+];
+
+/**
+ * Tipos de alerta soportados con su configuración por defecto.
+ */
+const ALERT_TYPES = {
+  declining_performance: {
+    label: 'Rendimiento en descenso',
+    thresholds: { warning: 10, critical: 20 }
+  },
+  inactivity: {
+    label: 'Inactividad',
+    thresholds: { info: 7, warning: 14 }
+  },
+  sudden_score_drop: {
+    label: 'Caída repentina de puntuación',
+    thresholds: { warning: 30 }
+  },
+  consistent_timeout: {
+    label: 'Timeouts consistentes',
+    thresholds: { warning: 0.3 }
+  },
+  improving_fast: {
+    label: 'Mejora rápida',
+    thresholds: { info: 15 }
+  },
+  plateau_detected: {
+    label: 'Estancamiento detectado',
+    thresholds: { info: 5 }
+  },
+  high_abandonment: {
+    label: 'Alto abandono',
+    thresholds: { warning: 0.25 }
+  }
+};
+
+/**
+ * Severidades de alertas, ordenadas de mayor a menor urgencia.
+ */
+const ALERT_SEVERITIES = ['critical', 'warning', 'info'];
+
+// ══════════════════════════════════════════════════════════════════════
+// Funciones de clasificación
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Clasifica un score en un tier de rendimiento.
+ *
+ * @param {number|null|undefined} score - Score promedio del estudiante (0-100)
+ * @returns {string} Tier: 'risk', 'average', 'good', 'excellent'
+ */
+const classifyTier = score => {
+  if (score === null || score === undefined || score < 0) {
+    return 'risk';
+  }
+  const found = PERFORMANCE_TIERS.find(t => score >= t.min && score <= t.max);
+  return found ? found.tier : 'risk';
+};
+
+/**
+ * Calcula la tasa de precisión (accuracy rate) como porcentaje.
+ *
+ * @param {number} correct - Respuestas correctas
+ * @param {number} errors - Respuestas incorrectas
+ * @returns {number} Porcentaje de precisión (0-100, un decimal)
+ */
+const calcAccuracyRate = (correct, errors) => {
+  const total = (correct || 0) + (errors || 0);
+  if (total === 0) {
+    return 0;
+  }
+  return Math.round(((correct || 0) / total) * 100 * 10) / 10;
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Helpers de fechas y rangos temporales
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula la fecha de inicio según un rango temporal.
+ *
+ * @param {string} timeRange - '7d', '30d' o '90d'
+ * @param {Date} [from=new Date()] - Fecha base (por defecto, ahora)
+ * @returns {Date} Fecha de inicio del rango
+ */
+const getStartDate = (timeRange, from = new Date()) => {
+  const start = new Date(from);
+  const days = { '7d': 7, '30d': 30, '90d': 90 };
+  start.setDate(start.getDate() - (days[timeRange] || 30));
+  return start;
+};
+
+/**
+ * Calcula ambas fechas (inicio del periodo actual e inicio del periodo anterior)
+ * para comparaciones período-sobre-período.
+ *
+ * @param {string} timeRange - '7d', '30d' o '90d'
+ * @returns {{ currentStart: Date, previousStart: Date, now: Date }}
+ */
+const getPeriodDates = timeRange => {
+  const now = new Date();
+  const days = { '7d': 7, '30d': 30, '90d': 90 };
+  const d = days[timeRange] || 30;
+
+  const currentStart = new Date(now);
+  currentStart.setDate(now.getDate() - d);
+
+  const previousStart = new Date(currentStart);
+  previousStart.setDate(currentStart.getDate() - d);
+
+  return { currentStart, previousStart, now };
+};
+
+/**
+ * Devuelve el inicio del día actual (00:00:00.000).
+ * @returns {Date}
+ */
+const getStartOfToday = () => {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Helpers de agregación
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Crea un ObjectId de Mongoose a partir de un string.
+ * Wrapper para evitar repetir `new mongoose.Types.ObjectId(...)`.
+ *
+ * @param {string} id - ID como string
+ * @returns {mongoose.Types.ObjectId}
+ */
+const toObjectId = id => new mongoose.Types.ObjectId(id);
+
+/**
+ * Pipeline stages comunes para filtrar GamePlays por sesiones de un profesor.
+ * Hace $lookup a game_sessions y filtra por createdBy.
+ *
+ * @param {string} teacherId - ID del profesor
+ * @returns {Array} Stages de pipeline ($lookup + $unwind + $match)
+ */
+const teacherSessionStages = teacherId => [
+  {
+    $lookup: {
+      from: 'game_sessions',
+      localField: 'sessionId',
+      foreignField: '_id',
+      as: 'session'
+    }
+  },
+  { $unwind: '$session' },
+  {
+    $match: {
+      'session.createdBy': toObjectId(teacherId)
+    }
+  }
+];
+
+/**
+ * Calcula la pendiente (slope) de una regresión lineal simple.
+ * Útil para determinar tendencias en series temporales.
+ *
+ * @param {Array<{x: number, y: number}>} points - Puntos de datos
+ * @returns {{ slope: number, intercept: number }}
+ */
+const linearRegression = points => {
+  const n = points.length;
+  if (n < 2) {
+    return { slope: 0, intercept: points[0]?.y || 0 };
+  }
+
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+
+  for (const { x, y } of points) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+
+  const denominator = n * sumXX - sumX * sumX;
+  if (denominator === 0) {
+    return { slope: 0, intercept: sumY / n };
+  }
+
+  const slope = (n * sumXY - sumX * sumY) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+
+  return { slope, intercept };
+};
+
+/**
+ * Determina la dirección de tendencia basándose en el slope y número de puntos.
+ *
+ * @param {number} slope - Pendiente de la regresión lineal
+ * @param {number} numPoints - Número de puntos de datos
+ * @returns {{ direction: string, confidence: string }}
+ */
+const classifyTrend = (slope, numPoints) => {
+  let direction;
+  if (slope > 0.5) {
+    direction = 'improving';
+  } else if (slope < -0.5) {
+    direction = 'declining';
+  } else {
+    direction = 'stable';
+  }
+
+  let confidence;
+  if (numPoints >= 7 && Math.abs(slope) > 1.0) {
+    confidence = 'high';
+  } else if (numPoints >= 4 || Math.abs(slope) > 0.5) {
+    confidence = 'medium';
+  } else {
+    confidence = 'low';
+  }
+
+  return { direction, confidence };
+};
+
+/**
+ * Genera un ID estable para una alerta basándose en tipo, estudiante y fecha.
+ * Permite al frontend trackear alertas como leídas/no leídas sin persistencia server-side.
+ *
+ * @param {string} type - Tipo de alerta
+ * @param {string} studentId - ID del estudiante
+ * @param {string} [dateStr] - Fecha opcional (por defecto, hoy)
+ * @returns {string} ID hash estable
+ */
+const generateAlertId = (type, studentId, dateStr) => {
+  const date = dateStr || new Date().toISOString().split('T')[0];
+  // Hash simple basado en string para generar ID determinista
+  const raw = `${type}:${studentId}:${date}`;
+  let hash = 0;
+  for (let i = 0; i < raw.length; i++) {
+    const chr = raw.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
+  }
+  return `alert_${Math.abs(hash).toString(36)}`;
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Framework KPI: umbrales RAG y generación de interpretaciones
+// Basado en Business Intelligence skill — ver Analytics_Design_Rationale.md
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Estados RAG (Red/Amber/Green) para indicadores.
+ * Cada KPI se clasifica en uno de estos estados.
+ */
+const RAG = { RED: 'RED', AMBER: 'AMBER', GREEN: 'GREEN' };
+
+/**
+ * Definiciones de KPI con umbrales RAG.
+ * Cada métrica define: nombre, unidad, dirección deseada, y umbrales.
+ *
+ * `direction`: 'higher_better' o 'lower_better'
+ * Los umbrales `green` y `red` definen los límites:
+ *   - higher_better: >= green → GREEN, < red → RED, entre ambos → AMBER
+ *   - lower_better:  <= green → GREEN, > red → RED, entre ambos → AMBER
+ */
+const KPI_DEFINITIONS = {
+  score: {
+    name: 'Puntuación media',
+    unit: 'puntos',
+    direction: 'higher_better',
+    green: 70,
+    red: 50,
+    target: 75,
+    formula: 'AVG(GamePlay.score) para partidas completadas'
+  },
+  accuracy: {
+    name: 'Tasa de acierto',
+    unit: '%',
+    direction: 'higher_better',
+    green: 75,
+    red: 50,
+    target: 80,
+    formula: 'correctAttempts / (correctAttempts + errorAttempts) * 100'
+  },
+  engagementScore: {
+    name: 'Puntuación de engagement',
+    unit: 'puntos',
+    direction: 'higher_better',
+    green: 60,
+    red: 35,
+    target: 70,
+    formula:
+      'Media ponderada: frecuencia(0.25) + regularidad(0.25) + completado(0.30) + intervalo(0.10) + replays(0.10)'
+  },
+  completionRate: {
+    name: 'Tasa de finalización',
+    unit: '%',
+    direction: 'higher_better',
+    green: 85,
+    red: 60,
+    target: 90,
+    formula: 'completedGames / totalGames * 100'
+  },
+  abandonmentRate: {
+    name: 'Tasa de abandono',
+    unit: '%',
+    direction: 'lower_better',
+    green: 10,
+    red: 25,
+    target: 5,
+    formula: 'abandonedGames / totalGames * 100'
+  },
+  responseTime: {
+    name: 'Tiempo medio de respuesta',
+    unit: 'ms',
+    direction: 'lower_better',
+    green: 4000,
+    red: 8000,
+    target: 3000,
+    formula: 'AVG(events.timeElapsed) excluyendo timeouts'
+  },
+  fatigueSlowdown: {
+    name: 'Desaceleración por fatiga',
+    unit: '%',
+    direction: 'lower_better',
+    green: 15,
+    red: 40,
+    target: 10,
+    formula: '((avgTimeSecondHalf - avgTimeFirstHalf) / avgTimeFirstHalf) * 100'
+  },
+  cardErrorRate: {
+    name: 'Tasa de error de tarjeta',
+    unit: '%',
+    direction: 'lower_better',
+    green: 30,
+    red: 60,
+    target: 20,
+    formula: '(errorCount + timeoutCount) / totalAttempts * 100'
+  },
+  learningRate: {
+    name: 'Tasa de aprendizaje',
+    unit: 'puntos/intento',
+    direction: 'higher_better',
+    green: 2,
+    red: 0,
+    target: 3,
+    formula: 'Pendiente de regresión lineal de scores sobre intentos'
+  },
+  trendSlope: {
+    name: 'Tendencia de rendimiento',
+    unit: 'puntos/periodo',
+    direction: 'higher_better',
+    green: 0.5,
+    red: -0.5,
+    target: 1.0,
+    formula: 'Pendiente de regresión lineal de scores sobre periodos temporales'
+  }
+};
+
+/**
+ * Clasifica un valor en estado RAG según la definición de su KPI.
+ *
+ * @param {string} kpiKey - Clave del KPI en KPI_DEFINITIONS
+ * @param {number} value - Valor actual de la métrica
+ * @returns {{ status: string, thresholds: Object }} Estado RAG y umbrales usados
+ */
+const classifyRAG = (kpiKey, value) => {
+  const def = KPI_DEFINITIONS[kpiKey];
+  if (!def) {
+    return { status: RAG.AMBER, thresholds: {} };
+  }
+
+  let status;
+  if (def.direction === 'higher_better') {
+    if (value >= def.green) {
+      status = RAG.GREEN;
+    } else if (value < def.red) {
+      status = RAG.RED;
+    } else {
+      status = RAG.AMBER;
+    }
+  } else {
+    if (value <= def.green) {
+      status = RAG.GREEN;
+    } else if (value > def.red) {
+      status = RAG.RED;
+    } else {
+      status = RAG.AMBER;
+    }
+  }
+
+  return {
+    status,
+    thresholds: { green: def.green, red: def.red, target: def.target }
+  };
+};
+
+/**
+ * Genera una interpretación en lenguaje natural para una métrica.
+ * Sigue el patrón What / So What / Now What del framework de BI.
+ * Mensajes en español para los profesores.
+ *
+ * @param {string} kpiKey - Clave del KPI
+ * @param {number} value - Valor actual
+ * @param {Object} [context] - Contexto adicional (studentName, etc.)
+ * @returns {{ whatHappened: string, soWhat: string, nowWhat: string }}
+ */
+const generateInterpretation = (kpiKey, value, context = {}) => {
+  const def = KPI_DEFINITIONS[kpiKey];
+  if (!def) {
+    return {
+      whatHappened: `Valor actual: ${value}`,
+      soWhat: '',
+      nowWhat: ''
+    };
+  }
+
+  const { status } = classifyRAG(kpiKey, value);
+  const name = context.studentName || 'El alumno';
+  const rounded = typeof value === 'number' ? Math.round(value * 10) / 10 : value;
+
+  const interpretations = {
+    score: {
+      [RAG.GREEN]: {
+        whatHappened: `${name} tiene una puntuación media de ${rounded} puntos`,
+        soWhat: 'El rendimiento está en un nivel bueno o excelente',
+        nowWhat: 'Mantener el nivel actual y considerar retos más desafiantes'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `${name} tiene una puntuación media de ${rounded} puntos`,
+        soWhat: 'El rendimiento está en un nivel promedio, hay margen de mejora',
+        nowWhat: 'Identificar los contextos temáticos donde más falla y reforzarlos'
+      },
+      [RAG.RED]: {
+        whatHappened: `${name} tiene una puntuación media de ${rounded} puntos`,
+        soWhat: 'El rendimiento está por debajo del umbral de riesgo',
+        nowWhat: 'Intervención recomendada: sesiones de refuerzo o revisión del material'
+      }
+    },
+    accuracy: {
+      [RAG.GREEN]: {
+        whatHappened: `Tasa de acierto del ${rounded}%`,
+        soWhat: 'El alumno comprende bien el material',
+        nowWhat: 'Mantener y avanzar a contenido más complejo'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tasa de acierto del ${rounded}%`,
+        soWhat: 'Acierta más de la mitad pero comete errores frecuentes',
+        nowWhat: 'Revisar qué tarjetas o conceptos causan más fallos'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tasa de acierto del ${rounded}%`,
+        soWhat: 'Falla más de lo que acierta, posible confusión con el material',
+        nowWhat: 'Simplificar el contenido o proporcionar apoyo adicional'
+      }
+    },
+    engagementScore: {
+      [RAG.GREEN]: {
+        whatHappened: `Engagement de ${rounded} sobre 100`,
+        soWhat: 'El alumno participa activamente y con regularidad',
+        nowWhat: 'El nivel de participación es saludable, mantener la dinámica actual'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Engagement de ${rounded} sobre 100`,
+        soWhat: 'La participación es moderada pero podría mejorar',
+        nowWhat: 'Considerar variar los contextos o mecánicas para aumentar la motivación'
+      },
+      [RAG.RED]: {
+        whatHappened: `Engagement de ${rounded} sobre 100`,
+        soWhat: 'El alumno muestra baja participación o interés',
+        nowWhat:
+          'Investigar posibles causas: contenido inadecuado, sesiones largas o dificultad excesiva'
+      }
+    },
+    completionRate: {
+      [RAG.GREEN]: {
+        whatHappened: `Completa el ${rounded}% de las partidas`,
+        soWhat: 'Termina casi todas las sesiones que empieza',
+        nowWhat: 'Buena señal de perseverancia, mantener la configuración actual'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Completa el ${rounded}% de las partidas`,
+        soWhat: 'Abandona algunas partidas antes de terminar',
+        nowWhat: 'Verificar si las sesiones son demasiado largas o difíciles'
+      },
+      [RAG.RED]: {
+        whatHappened: `Solo completa el ${rounded}% de las partidas`,
+        soWhat: 'Abandona con frecuencia, posible frustración o desinterés',
+        nowWhat: 'Reducir la duración de las sesiones y revisar la dificultad del contenido'
+      }
+    },
+    abandonmentRate: {
+      [RAG.GREEN]: {
+        whatHappened: `Tasa de abandono del ${rounded}%`,
+        soWhat: 'El abandono está dentro de niveles normales',
+        nowWhat: 'No se requiere acción'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tasa de abandono del ${rounded}%`,
+        soWhat: 'El abandono está por encima de lo ideal',
+        nowWhat: 'Revisar qué sesiones generan más abandonos y ajustar su configuración'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tasa de abandono del ${rounded}%`,
+        soWhat: 'Nivel de abandono alto, indica un problema sistemático',
+        nowWhat:
+          'Acción urgente: acortar sesiones, simplificar contenido o verificar problemas técnicos'
+      }
+    },
+    responseTime: {
+      [RAG.GREEN]: {
+        whatHappened: `Tiempo medio de respuesta de ${Math.round((rounded / 1000) * 10) / 10} segundos`,
+        soWhat: 'Responde con rapidez, buena comprensión del material',
+        nowWhat: 'El ritmo es adecuado para su edad'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tiempo medio de respuesta de ${Math.round((rounded / 1000) * 10) / 10} segundos`,
+        soWhat: 'Tarda un poco más de lo esperado en responder',
+        nowWhat: 'Puede necesitar más tiempo de familiarización con el contenido'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tiempo medio de respuesta de ${Math.round((rounded / 1000) * 10) / 10} segundos`,
+        soWhat: 'Tiempos muy altos, posible confusión o distracción',
+        nowWhat: 'Considerar aumentar el tiempo límite o simplificar las opciones'
+      }
+    },
+    fatigueSlowdown: {
+      [RAG.GREEN]: {
+        whatHappened: `Desaceleración del ${rounded}% entre primera y segunda mitad`,
+        soWhat: 'No se detecta fatiga significativa',
+        nowWhat: 'La duración de las sesiones es adecuada'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Desaceleración del ${rounded}% entre primera y segunda mitad`,
+        soWhat: 'Se detecta fatiga moderada hacia el final de la partida',
+        nowWhat: 'Considerar reducir el número de rondas por sesión'
+      },
+      [RAG.RED]: {
+        whatHappened: `Desaceleración del ${rounded}% entre primera y segunda mitad`,
+        soWhat: 'Fatiga significativa: el alumno se ralentiza mucho al final',
+        nowWhat: 'Reducir la duración de las sesiones o añadir descansos'
+      }
+    },
+    cardErrorRate: {
+      [RAG.GREEN]: {
+        whatHappened: `Tasa de error del ${rounded}% en esta tarjeta`,
+        soWhat: 'La mayoría de los alumnos aciertan esta tarjeta',
+        nowWhat: 'El contenido de esta tarjeta es adecuado'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tasa de error del ${rounded}% en esta tarjeta`,
+        soWhat: 'Algunos alumnos tienen dificultades con esta tarjeta',
+        nowWhat: 'Monitorizar; si persiste, revisar el contenido asociado'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tasa de error del ${rounded}% en esta tarjeta`,
+        soWhat: 'La mayoría de los alumnos fallan esta tarjeta',
+        nowWhat: 'Revisar el contenido: el problema es el material, no los alumnos'
+      }
+    },
+    learningRate: {
+      [RAG.GREEN]: {
+        whatHappened: `Tasa de aprendizaje de ${rounded} puntos por intento`,
+        soWhat: 'Los alumnos mejoran con la repetición de este contenido',
+        nowWhat: 'El contenido es efectivo para el aprendizaje'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tasa de aprendizaje de ${rounded} puntos por intento`,
+        soWhat: 'La mejora con la repetición es lenta',
+        nowWhat: 'Considerar enriquecer el contenido con pistas o variaciones'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tasa de aprendizaje de ${rounded} puntos por intento`,
+        soWhat: 'No hay mejora con la repetición; el formato no funciona',
+        nowWhat: 'Cambiar el enfoque didáctico para este contenido'
+      }
+    },
+    trendSlope: {
+      [RAG.GREEN]: {
+        whatHappened: `Tendencia positiva de +${rounded} puntos por periodo`,
+        soWhat: 'El alumno está mejorando de forma sostenida',
+        nowWhat: 'Mantener el enfoque actual'
+      },
+      [RAG.AMBER]: {
+        whatHappened: `Tendencia estable (${rounded > 0 ? '+' : ''}${rounded} puntos por periodo)`,
+        soWhat: 'El rendimiento se mantiene sin cambios significativos',
+        nowWhat: 'Considerar nuevos estímulos si lleva varias semanas estable'
+      },
+      [RAG.RED]: {
+        whatHappened: `Tendencia negativa de ${rounded} puntos por periodo`,
+        soWhat: 'El rendimiento está empeorando',
+        nowWhat: 'Investigar la causa y considerar intervención'
+      }
+    }
+  };
+
+  const kpiInterpretations = interpretations[kpiKey];
+  if (!kpiInterpretations) {
+    return {
+      whatHappened: `${def.name}: ${rounded} ${def.unit}`,
+      soWhat: status === RAG.GREEN ? 'Dentro del rango esperado' : 'Fuera del rango óptimo',
+      nowWhat: status === RAG.RED ? 'Se recomienda revisar' : 'Monitorizar'
+    };
+  }
+
+  return kpiInterpretations[status] || kpiInterpretations[RAG.AMBER];
+};
+
+/**
+ * Enriquece un valor numérico con estado RAG e interpretación.
+ * Función de conveniencia que combina classifyRAG + generateInterpretation.
+ *
+ * @param {string} kpiKey - Clave del KPI
+ * @param {number} value - Valor actual
+ * @param {Object} [context] - Contexto adicional
+ * @returns {{ value: number, rag: Object, interpretation: Object, kpiMeta: Object }}
+ */
+const enrichMetric = (kpiKey, value, context = {}) => {
+  const def = KPI_DEFINITIONS[kpiKey];
+  const { status, thresholds } = classifyRAG(kpiKey, value);
+  const interpretation = generateInterpretation(kpiKey, value, context);
+
+  return {
+    value: typeof value === 'number' ? Math.round(value * 10) / 10 : value,
+    rag: { status, thresholds },
+    interpretation,
+    kpiMeta: def
+      ? { name: def.name, unit: def.unit, target: def.target, formula: def.formula }
+      : null
+  };
+};
+
+module.exports = {
+  PERFORMANCE_TIERS,
+  ALERT_TYPES,
+  ALERT_SEVERITIES,
+  KPI_DEFINITIONS,
+  RAG,
+  classifyTier,
+  calcAccuracyRate,
+  getStartDate,
+  getPeriodDates,
+  getStartOfToday,
+  toObjectId,
+  teacherSessionStages,
+  linearRegression,
+  classifyTrend,
+  generateAlertId,
+  classifyRAG,
+  generateInterpretation,
+  enrichMetric
+};

--- a/backend/src/services/analytics/analyticsHelpers.js
+++ b/backend/src/services/analytics/analyticsHelpers.js
@@ -7,6 +7,13 @@
  * también existen en analyticsService.js (servicio original). No se refactorizan
  * allí para mantener zero regresión — ver ADR-026.
  *
+ * CONVENCIÓN DE ERRORES en los sub-servicios de analytics:
+ * - Funciones de entidad (por ID específico, ej. getGameplayRounds, getStudentReport):
+ *   lanzan NotFoundError si el recurso no existe.
+ * - Funciones de agregación (sobre datasets, ej. getClassroomEngagement, getAlerts):
+ *   devuelven arrays vacíos u objetos con valores por defecto (0, []).
+ *   No tener datos no es un error; significa que el alumno/clase aún no ha jugado.
+ *
  * @module services/analytics/analyticsHelpers
  */
 

--- a/backend/src/services/analytics/contentEffectivenessService.js
+++ b/backend/src/services/analytics/contentEffectivenessService.js
@@ -1,0 +1,387 @@
+/**
+ * @fileoverview Servicio de análisis de efectividad de contenido.
+ * Evalúa qué contextos/mecánicas producen mejor aprendizaje,
+ * identifica tarjetas problemáticas y calcula curvas de aprendizaje.
+ *
+ * Ver Analytics_Design_Rationale.md § 2.4 para fundamentación pedagógica.
+ *
+ * @module services/analytics/contentEffectivenessService
+ */
+
+const gamePlayRepository = require('../../repositories/gamePlayRepository');
+const { toObjectId, getStartDate, linearRegression, enrichMetric } = require('./analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// E12 — Efectividad de contenido por contexto/mecánica
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Analiza qué contextos o mecánicas producen mejor aprendizaje.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.groupBy='context']
+ * @returns {Promise<Object>} { items, groupBy }
+ */
+async function getContentEffectiveness(teacherId, { timeRange = '30d', groupBy = 'context' } = {}) {
+  const startDate = getStartDate(timeRange);
+  const lookupCollection = groupBy === 'context' ? 'game_contexts' : 'game_mechanics';
+  const lookupField = groupBy === 'context' ? 'session.contextId' : 'session.mechanicId';
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    {
+      $match: {
+        'session.createdBy': toObjectId(teacherId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $lookup: {
+        from: lookupCollection,
+        localField: lookupField,
+        foreignField: '_id',
+        as: 'entity'
+      }
+    },
+    { $unwind: '$entity' },
+    {
+      $group: {
+        _id: { entityId: '$entity._id', entityName: '$entity.name' },
+        avgScore: { $avg: '$score' },
+        avgAccuracy: {
+          $avg: {
+            $cond: [
+              { $gt: ['$metrics.totalAttempts', 0] },
+              {
+                $multiply: [
+                  { $divide: ['$metrics.correctAttempts', '$metrics.totalAttempts'] },
+                  100
+                ]
+              },
+              0
+            ]
+          }
+        },
+        totalPlays: { $sum: 1 },
+        uniqueStudents: { $addToSet: '$playerId' },
+        avgCompletionTime: { $avg: '$metrics.completionTime' },
+        // Para calcular improvement rate: guardar scores con fecha
+        scoreDates: {
+          $push: {
+            score: '$score',
+            date: '$completedAt'
+          }
+        }
+      }
+    },
+    {
+      $project: {
+        _id: 0,
+        name: '$_id.entityName',
+        id: '$_id.entityId',
+        avgScore: { $round: ['$avgScore', 1] },
+        avgAccuracy: { $round: ['$avgAccuracy', 1] },
+        totalPlays: 1,
+        uniqueStudents: { $size: '$uniqueStudents' },
+        avgCompletionTime: { $round: ['$avgCompletionTime', 0] },
+        scoreDates: 1
+      }
+    },
+    { $sort: { avgScore: -1 } }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+
+  // Calcular improvement rate y learning efficiency para cada item
+  const items = results.map(r => {
+    // Improvement rate: pendiente de scores a lo largo del tiempo
+    const sortedScores = r.scoreDates
+      .sort((a, b) => new Date(a.date) - new Date(b.date))
+      .map((sd, i) => ({ x: i, y: sd.score }));
+
+    const { slope } = linearRegression(sortedScores);
+
+    let learningEfficiency;
+    if (slope > 1) {
+      learningEfficiency = 'high';
+    } else if (slope > 0) {
+      learningEfficiency = 'medium';
+    } else {
+      learningEfficiency = 'low';
+    }
+
+    // Enriquecer con RAG e interpretación (framework BI)
+    const scoreEnriched = enrichMetric('score', r.avgScore);
+    const learningEnriched = enrichMetric('learningRate', slope);
+
+    return {
+      name: r.name,
+      id: r.id.toString(),
+      avgScore: r.avgScore,
+      avgAccuracy: r.avgAccuracy,
+      totalPlays: r.totalPlays,
+      uniqueStudents: r.uniqueStudents,
+      avgCompletionTime: r.avgCompletionTime,
+      improvementRate: Math.round(slope * 100) / 100,
+      learningEfficiency,
+      scoreRag: scoreEnriched.rag,
+      learningRag: learningEnriched.rag,
+      interpretation: learningEnriched.interpretation
+    };
+  });
+
+  return { items, groupBy };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E13 — Tarjetas con dificultad alta
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Identifica tarjetas RFID con tasa de error por encima de un umbral.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.contextId]
+ * @param {number} [options.threshold=40]
+ * @returns {Promise<Object>} { flaggedCards, totalCardsAnalyzed, cardsAboveThreshold }
+ */
+async function getCardDifficulty(teacherId, { timeRange = '30d', contextId, threshold = 40 } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const matchStage = {
+    'session.createdBy': toObjectId(teacherId),
+    status: 'completed',
+    completedAt: { $gte: startDate }
+  };
+
+  if (contextId) {
+    matchStage['session.contextId'] = toObjectId(contextId);
+  }
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    { $match: matchStage },
+    {
+      $lookup: {
+        from: 'game_contexts',
+        localField: 'session.contextId',
+        foreignField: '_id',
+        as: 'context'
+      }
+    },
+    { $unwind: { path: '$context', preserveNullAndEmptyArrays: true } },
+    { $unwind: '$events' },
+    {
+      $match: {
+        'events.eventType': { $in: ['correct', 'error', 'timeout'] },
+        'events.cardUid': { $ne: null }
+      }
+    },
+    {
+      $group: {
+        _id: '$events.cardUid',
+        totalAttempts: { $sum: 1 },
+        errorCount: {
+          $sum: { $cond: [{ $eq: ['$events.eventType', 'error'] }, 1, 0] }
+        },
+        timeoutCount: {
+          $sum: { $cond: [{ $eq: ['$events.eventType', 'timeout'] }, 1, 0] }
+        },
+        uniqueStudents: { $addToSet: '$playerId' },
+        contextName: { $first: '$context.name' },
+        sampleExpectedValue: { $first: '$events.expectedValue' }
+      }
+    },
+    {
+      $addFields: {
+        errorRate: {
+          $round: [
+            {
+              $multiply: [
+                { $divide: [{ $add: ['$errorCount', '$timeoutCount'] }, '$totalAttempts'] },
+                100
+              ]
+            },
+            1
+          ]
+        },
+        difficultyIndex: {
+          $round: [{ $divide: [{ $add: ['$errorCount', '$timeoutCount'] }, '$totalAttempts'] }, 2]
+        },
+        studentsAttempted: { $size: '$uniqueStudents' }
+      }
+    },
+    { $sort: { errorRate: -1 } }
+  ];
+
+  const allCards = await gamePlayRepository.aggregate(pipeline);
+
+  const flaggedCards = allCards
+    .filter(c => c.errorRate >= threshold && c.studentsAttempted >= 3)
+    .map(c => {
+      const cardEnriched = enrichMetric('cardErrorRate', c.errorRate);
+      return {
+        cardUid: c._id,
+        assignedValue: c.sampleExpectedValue || 'Desconocido',
+        contextName: c.contextName || 'Sin contexto',
+        errorRate: c.errorRate,
+        difficultyIndex: c.difficultyIndex,
+        studentsAttempted: c.studentsAttempted,
+        rag: cardEnriched.rag,
+        interpretation: cardEnriched.interpretation
+      };
+    });
+
+  return {
+    flaggedCards,
+    totalCardsAnalyzed: allCards.length,
+    cardsAboveThreshold: flaggedCards.length
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E14 — Curvas de aprendizaje por contenido
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula curvas de aprendizaje: ¿mejoran los scores con la repetición?
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='90d']
+ * @param {string} [options.contextId]
+ * @param {string} [options.mechanicId]
+ * @returns {Promise<Object>} { curves }
+ */
+async function getLearningCurves(teacherId, { timeRange = '90d', contextId, mechanicId } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const sessionMatch = { 'session.createdBy': toObjectId(teacherId) };
+  if (contextId) {
+    sessionMatch['session.contextId'] = toObjectId(contextId);
+  }
+  if (mechanicId) {
+    sessionMatch['session.mechanicId'] = toObjectId(mechanicId);
+  }
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    {
+      $match: {
+        ...sessionMatch,
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $lookup: {
+        from: 'game_contexts',
+        localField: 'session.contextId',
+        foreignField: '_id',
+        as: 'context'
+      }
+    },
+    { $unwind: { path: '$context', preserveNullAndEmptyArrays: true } },
+    { $sort: { playerId: 1, 'context._id': 1, completedAt: 1 } },
+    {
+      $group: {
+        _id: { playerId: '$playerId', contextId: '$context._id', contextName: '$context.name' },
+        plays: { $push: { score: '$score', date: '$completedAt' } }
+      }
+    }
+  ];
+
+  const playerContextPlays = await gamePlayRepository.aggregate(pipeline);
+
+  // Agrupar por contexto y calcular score promedio por número de intento
+  const contextMap = {};
+
+  for (const pcp of playerContextPlays) {
+    const contextId2 = pcp._id.contextId?.toString() || 'unknown';
+    const contextName = pcp._id.contextName || 'Desconocido';
+
+    if (!contextMap[contextId2]) {
+      contextMap[contextId2] = { name: contextName, id: contextId2, playNumberScores: {} };
+    }
+
+    // Numerar partidas secuencialmente para este alumno+contexto
+    pcp.plays.forEach((play, index) => {
+      const playNumber = index + 1;
+      if (!contextMap[contextId2].playNumberScores[playNumber]) {
+        contextMap[contextId2].playNumberScores[playNumber] = [];
+      }
+      contextMap[contextId2].playNumberScores[playNumber].push(play.score);
+    });
+  }
+
+  // Construir curvas
+  const curves = Object.values(contextMap).map(ctx => {
+    const dataPoints = Object.entries(ctx.playNumberScores)
+      .map(([pn, scores]) => ({
+        playNumber: parseInt(pn, 10),
+        avgScore: Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 10) / 10,
+        sampleSize: scores.length
+      }))
+      .filter(dp => dp.sampleSize >= 2) // Necesitamos al menos 2 alumnos para ser significativo
+      .sort((a, b) => a.playNumber - b.playNumber);
+
+    // Calcular learning rate
+    const points = dataPoints.map(dp => ({ x: dp.playNumber, y: dp.avgScore }));
+    const { slope } = linearRegression(points);
+
+    // Detectar punto de plateau
+    let plateauAt = null;
+    for (let i = 1; i < dataPoints.length; i++) {
+      const improvement = dataPoints[i].avgScore - dataPoints[i - 1].avgScore;
+      if (improvement < 1 && i >= 3) {
+        plateauAt = dataPoints[i].playNumber;
+        break;
+      }
+    }
+
+    return {
+      name: ctx.name,
+      id: ctx.id,
+      dataPoints,
+      learningRate: Math.round(slope * 100) / 100,
+      plateauAt
+    };
+  });
+
+  return { curves };
+}
+
+module.exports = {
+  getContentEffectiveness,
+  getCardDifficulty,
+  getLearningCurves
+};

--- a/backend/src/services/analytics/engagementService.js
+++ b/backend/src/services/analytics/engagementService.js
@@ -1,0 +1,415 @@
+/**
+ * @fileoverview Servicio de métricas de engagement.
+ * Mide la participación, frecuencia, regularidad, tasa de completado,
+ * replays voluntarios y patrones de juego.
+ *
+ * Ver Analytics_Design_Rationale.md § 2.3 para fundamentación pedagógica.
+ *
+ * @module services/analytics/engagementService
+ */
+
+const gamePlayRepository = require('../../repositories/gamePlayRepository');
+const userRepository = require('../../repositories/userRepository');
+const { toObjectId, getStartDate, enrichMetric } = require('./analyticsHelpers');
+
+// Pesos del engagement score (ver Analytics_Design_Rationale.md)
+const ENGAGEMENT_WEIGHTS = {
+  playFrequency: 0.25,
+  regularity: 0.25,
+  completionRate: 0.3,
+  timeBetweenSessions: 0.1,
+  voluntaryReplays: 0.1
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// E09 — Engagement individual del estudiante
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula el engagement score y sus componentes para un estudiante.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @returns {Promise<Object>} { engagementScore, components, abandonmentAnalysis }
+ */
+async function getStudentEngagement(studentId, { timeRange = '30d' } = {}) {
+  const startDate = getStartDate(timeRange);
+  const days = timeRange === '90d' ? 90 : 30;
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        startedAt: { $gte: startDate }
+      }
+    },
+    {
+      $facet: {
+        statusCounts: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
+        dailyActivity: [
+          {
+            $group: {
+              _id: { $dateToString: { format: '%Y-%m-%d', date: '$startedAt' } },
+              count: { $sum: 1 }
+            }
+          },
+          { $sort: { _id: 1 } }
+        ],
+        replays: [
+          { $group: { _id: '$sessionId', count: { $sum: 1 } } },
+          { $match: { count: { $gt: 1 } } },
+          { $count: 'replayCount' }
+        ],
+        completedDates: [
+          { $match: { status: 'completed' } },
+          { $sort: { completedAt: 1 } },
+          { $group: { _id: null, dates: { $push: '$completedAt' } } }
+        ],
+        abandonmentDetails: [
+          { $match: { status: 'abandoned' } },
+          {
+            $lookup: {
+              from: 'game_sessions',
+              localField: 'sessionId',
+              foreignField: '_id',
+              as: 'session'
+            }
+          },
+          { $unwind: '$session' },
+          {
+            $lookup: {
+              from: 'game_contexts',
+              localField: 'session.contextId',
+              foreignField: '_id',
+              as: 'context'
+            }
+          },
+          { $unwind: { path: '$context', preserveNullAndEmptyArrays: true } },
+          {
+            $group: {
+              _id: '$context.name',
+              count: { $sum: 1 },
+              avgRoundAbandoned: { $avg: '$currentRound' }
+            }
+          },
+          { $sort: { count: -1 } }
+        ]
+      }
+    }
+  ];
+
+  const [result] = await gamePlayRepository.aggregate(pipeline);
+
+  // Extraer datos
+  const statusMap = {};
+  for (const s of result.statusCounts) {
+    statusMap[s._id] = s.count;
+  }
+
+  const completed = statusMap.completed || 0;
+  const abandoned = statusMap.abandoned || 0;
+  const total = completed + abandoned + (statusMap['in-progress'] || 0) + (statusMap.paused || 0);
+
+  const daysActive = result.dailyActivity.length;
+  const totalWeeks = Math.max(days / 7, 1);
+  const gamesPerWeek = total / totalWeeks;
+
+  const replayCount = result.replays[0]?.replayCount || 0;
+
+  // Calcular tiempo medio entre sesiones
+  let avgDaysBetween = 0;
+  const completedDates = result.completedDates[0]?.dates || [];
+  if (completedDates.length >= 2) {
+    let totalDiffs = 0;
+    for (let i = 1; i < completedDates.length; i++) {
+      totalDiffs +=
+        (new Date(completedDates[i]) - new Date(completedDates[i - 1])) / (1000 * 60 * 60 * 24);
+    }
+    avgDaysBetween = totalDiffs / (completedDates.length - 1);
+  }
+
+  // Normalizar componentes a 0-100
+  const components = {
+    playFrequency: {
+      value: Math.round(gamesPerWeek * 10) / 10,
+      unit: 'juegos/semana',
+      score: Math.round(Math.min(gamesPerWeek / 5, 1) * 100)
+    },
+    regularity: {
+      value: Math.round((daysActive / days) * 100) / 100,
+      description: `${daysActive} de ${days} días activo`,
+      score: Math.round((daysActive / Math.min(days, 30)) * 100)
+    },
+    completionRate: {
+      value: total > 0 ? Math.round((completed / total) * 100 * 10) / 10 : 0,
+      completed,
+      total,
+      score: total > 0 ? Math.round((completed / total) * 100) : 0
+    },
+    avgTimeBetweenSessions: {
+      value: Math.round(avgDaysBetween * 10) / 10,
+      unit: 'días',
+      score: Math.round(Math.max(1 - avgDaysBetween / 7, 0) * 100)
+    },
+    voluntaryReplays: {
+      value: replayCount,
+      description: 'Sesiones jugadas múltiples veces',
+      score: Math.round(Math.min(replayCount / 3, 1) * 100)
+    }
+  };
+
+  // Calcular engagement score ponderado
+  const engagementScore = Math.round(
+    components.playFrequency.score * ENGAGEMENT_WEIGHTS.playFrequency +
+      components.regularity.score * ENGAGEMENT_WEIGHTS.regularity +
+      components.completionRate.score * ENGAGEMENT_WEIGHTS.completionRate +
+      components.avgTimeBetweenSessions.score * ENGAGEMENT_WEIGHTS.timeBetweenSessions +
+      components.voluntaryReplays.score * ENGAGEMENT_WEIGHTS.voluntaryReplays
+  );
+
+  // Análisis de abandono
+  const abandonmentAnalysis = {
+    abandonedGames: abandoned,
+    abandonmentRate: total > 0 ? Math.round((abandoned / total) * 100 * 10) / 10 : 0,
+    avgRoundWhenAbandoned: 0,
+    commonAbandonmentContexts: result.abandonmentDetails.map(d => ({
+      name: d._id || 'Sin contexto',
+      count: d.count
+    }))
+  };
+
+  if (result.abandonmentDetails.length > 0) {
+    const totalAvgRound = result.abandonmentDetails.reduce(
+      (sum, d) => sum + d.avgRoundAbandoned * d.count,
+      0
+    );
+    const totalAbandoned = result.abandonmentDetails.reduce((sum, d) => sum + d.count, 0);
+    abandonmentAnalysis.avgRoundWhenAbandoned =
+      totalAbandoned > 0 ? Math.round((totalAvgRound / totalAbandoned) * 10) / 10 : 0;
+  }
+
+  // Enriquecer con RAG e interpretación (framework BI)
+  const engagementEnriched = enrichMetric('engagementScore', engagementScore);
+  const completionEnriched = enrichMetric('completionRate', components.completionRate.value);
+  const abandonmentEnriched = enrichMetric('abandonmentRate', abandonmentAnalysis.abandonmentRate);
+
+  return {
+    engagementScore,
+    rag: engagementEnriched.rag,
+    interpretation: engagementEnriched.interpretation,
+    components,
+    abandonmentAnalysis: {
+      ...abandonmentAnalysis,
+      rag: abandonmentEnriched.rag,
+      interpretation: abandonmentEnriched.interpretation
+    },
+    completionRag: completionEnriched.rag
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E10 — Engagement agregado de clase
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula engagement agregado de toda la clase.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.sort='engagementScore']
+ * @param {string} [options.order='desc']
+ * @returns {Promise<Object>}
+ */
+async function getClassroomEngagement(
+  teacherId,
+  { timeRange = '30d', sort = 'engagementScore', order = 'desc' } = {}
+) {
+  const startDate = getStartDate(timeRange);
+
+  // Obtener estudiantes
+  const students = await userRepository.find(
+    { createdBy: toObjectId(teacherId), role: 'student', status: 'active' },
+    { select: 'name' }
+  );
+
+  if (students.length === 0) {
+    return {
+      classEngagementScore: 0,
+      classCompletionRate: 0,
+      students: [],
+      abandonmentRate: 0
+    };
+  }
+
+  const studentIds = students.map(s => toObjectId(s._id));
+
+  // Pipeline de engagement por estudiante
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        startedAt: { $gte: startDate }
+      }
+    },
+    {
+      $group: {
+        _id: '$playerId',
+        total: { $sum: 1 },
+        completed: { $sum: { $cond: [{ $eq: ['$status', 'completed'] }, 1, 0] } },
+        abandoned: { $sum: { $cond: [{ $eq: ['$status', 'abandoned'] }, 1, 0] } },
+        daysActive: { $addToSet: { $dateToString: { format: '%Y-%m-%d', date: '$startedAt' } } },
+        sessions: { $addToSet: '$sessionId' }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+  const studentMap = new Map(students.map(s => [s._id.toString(), s.name]));
+  const days = timeRange === '90d' ? 90 : 30;
+
+  let totalEngagement = 0;
+  let totalCompleted = 0;
+  let totalGames = 0;
+  let totalAbandoned = 0;
+
+  const studentResults = results.map(r => {
+    const sid = r._id.toString();
+    const completionRate = r.total > 0 ? (r.completed / r.total) * 100 : 0;
+    const gamesPerWeek = r.total / Math.max(days / 7, 1);
+    const regularityScore = Math.round((r.daysActive.length / Math.min(days, 30)) * 100);
+
+    // Engagement simplificado para la vista de clase
+    const engagement = Math.round(
+      Math.min(gamesPerWeek / 5, 1) * 100 * ENGAGEMENT_WEIGHTS.playFrequency +
+        regularityScore * ENGAGEMENT_WEIGHTS.regularity +
+        completionRate * ENGAGEMENT_WEIGHTS.completionRate
+    );
+
+    totalEngagement += engagement;
+    totalCompleted += r.completed;
+    totalGames += r.total;
+    totalAbandoned += r.abandoned;
+
+    return {
+      studentId: sid,
+      name: studentMap.get(sid) || 'Desconocido',
+      engagementScore: engagement,
+      completionRate: Math.round(completionRate * 10) / 10,
+      playFrequency: Math.round(gamesPerWeek * 10) / 10,
+      gamesPlayed: r.total
+    };
+  });
+
+  // Ordenar
+  const sortField = sort;
+  const multiplier = order === 'asc' ? 1 : -1;
+  studentResults.sort((a, b) => (a[sortField] - b[sortField]) * multiplier);
+
+  return {
+    classEngagementScore:
+      studentResults.length > 0 ? Math.round(totalEngagement / studentResults.length) : 0,
+    classCompletionRate:
+      totalGames > 0 ? Math.round((totalCompleted / totalGames) * 100 * 10) / 10 : 0,
+    students: studentResults,
+    abandonmentRate: totalGames > 0 ? Math.round((totalAbandoned / totalGames) * 100 * 10) / 10 : 0
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E11 — Patrones de juego del estudiante
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene patrones de juego de un estudiante: horarios, timeline, etc.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @returns {Promise<Object>}
+ */
+async function getStudentPlayPatterns(studentId, { timeRange = '30d' } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        startedAt: { $gte: startDate }
+      }
+    },
+    {
+      $facet: {
+        statusCounts: [{ $group: { _id: '$status', count: { $sum: 1 } } }],
+        hourDistribution: [
+          {
+            $group: {
+              _id: { $hour: '$startedAt' },
+              count: { $sum: 1 }
+            }
+          },
+          { $sort: { count: -1 } }
+        ],
+        dayDistribution: [
+          {
+            $group: {
+              _id: { $dayOfWeek: '$startedAt' },
+              count: { $sum: 1 }
+            }
+          },
+          { $sort: { count: -1 } }
+        ],
+        dailyTimeline: [
+          { $match: { status: 'completed' } },
+          {
+            $group: {
+              _id: { $dateToString: { format: '%Y-%m-%d', date: '$startedAt' } },
+              gamesPlayed: { $sum: 1 },
+              avgScore: { $avg: '$score' }
+            }
+          },
+          { $sort: { _id: 1 } }
+        ],
+        lastGame: [{ $sort: { startedAt: -1 } }, { $limit: 1 }, { $project: { startedAt: 1 } }]
+      }
+    }
+  ];
+
+  const [result] = await gamePlayRepository.aggregate(pipeline);
+
+  const statusMap = {};
+  for (const s of result.statusCounts) {
+    statusMap[s._id] = s.count;
+  }
+
+  const now = new Date();
+  const lastPlayedAt = result.lastGame[0]?.startedAt;
+  const daysSinceLastPlay = lastPlayedAt
+    ? Math.floor((now - new Date(lastPlayedAt)) / (1000 * 60 * 60 * 24))
+    : null;
+
+  return {
+    totalGames:
+      (statusMap.completed || 0) +
+      (statusMap.abandoned || 0) +
+      (statusMap['in-progress'] || 0) +
+      (statusMap.paused || 0),
+    completedGames: statusMap.completed || 0,
+    abandonedGames: statusMap.abandoned || 0,
+    daysSinceLastPlay,
+    favoriteHour: result.hourDistribution[0]?._id ?? null,
+    favoriteDayOfWeek: result.dayDistribution[0]?._id ?? null,
+    sessionsTimeline: result.dailyTimeline.map(d => ({
+      date: d._id,
+      gamesPlayed: d.gamesPlayed,
+      avgScore: Math.round(d.avgScore * 10) / 10
+    }))
+  };
+}
+
+module.exports = {
+  getStudentEngagement,
+  getClassroomEngagement,
+  getStudentPlayPatterns
+};

--- a/backend/src/services/analytics/index.js
+++ b/backend/src/services/analytics/index.js
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Re-exporta todos los sub-servicios de analytics avanzados.
+ *
+ * Uso: const { getAlerts, getStudentTrajectory } = require('./analytics');
+ *
+ * @module services/analytics
+ */
+
+module.exports = {
+  ...require('./alertsService'),
+  ...require('./studentTrajectoryService'),
+  ...require('./sessionAnalysisService'),
+  ...require('./engagementService'),
+  ...require('./contentEffectivenessService'),
+  ...require('./reportDataService')
+};

--- a/backend/src/services/analytics/reportDataService.js
+++ b/backend/src/services/analytics/reportDataService.js
@@ -1,0 +1,275 @@
+/**
+ * @fileoverview Servicio de datos estructurados para reportes y exportación.
+ * Orquesta llamadas a otros sub-servicios para generar reportes completos.
+ *
+ * Ver Analytics_Design_Rationale.md § 2.6 para fundamentación pedagógica.
+ *
+ * @module services/analytics/reportDataService
+ */
+
+const analyticsService = require('../analyticsService');
+const userRepository = require('../../repositories/userRepository');
+const studentTrajectoryService = require('./studentTrajectoryService');
+const engagementService = require('./engagementService');
+const sessionAnalysisService = require('./sessionAnalysisService');
+const alertsService = require('./alertsService');
+const contentEffectivenessService = require('./contentEffectivenessService');
+const { toObjectId, classifyTier, calcAccuracyRate, enrichMetric } = require('./analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// E17 — Reporte completo de un estudiante
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Genera datos completos de reporte para un estudiante individual.
+ * Orquesta llamadas a múltiples sub-servicios.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.format='summary']
+ * @returns {Promise<Object>}
+ */
+async function getStudentReport(studentId, { timeRange = '30d', format = 'summary' } = {}) {
+  // Obtener datos del estudiante
+  const student = await userRepository.findById(studentId, {
+    select: 'name profile.classroom profile.age profile.avatar studentMetrics'
+  });
+
+  if (!student) {
+    const { NotFoundError } = require('../../utils/errors');
+    throw new NotFoundError('Estudiante no encontrado');
+  }
+
+  const metrics = student.studentMetrics || {};
+  const tier = classifyTier(metrics.averageScore);
+  const accuracy = calcAccuracyRate(metrics.totalCorrectAnswers, metrics.totalErrors);
+
+  // Enriquecer métricas con RAG (framework BI)
+  const scoreEnriched = enrichMetric('score', metrics.averageScore || 0);
+  const accuracyEnriched = enrichMetric('accuracy', accuracy);
+  const responseTimeEnriched = enrichMetric('responseTime', metrics.averageResponseTime || 0);
+
+  // Obtener datos en paralelo
+  const promises = [
+    studentTrajectoryService.getStudentTrajectory(studentId, { timeRange }),
+    engagementService.getStudentEngagement(studentId, {
+      timeRange: timeRange === '7d' ? '30d' : timeRange
+    })
+  ];
+
+  if (format === 'detailed') {
+    promises.push(
+      sessionAnalysisService.getStudentStruggles(studentId, { timeRange }),
+      studentTrajectoryService.getStudentEvolution(studentId, { timeRange, groupBy: 'context' }),
+      studentTrajectoryService.getStudentEvolution(studentId, { timeRange, groupBy: 'mechanic' })
+    );
+  }
+
+  const results = await Promise.all(promises);
+
+  // Estructura jerárquica: Summary → Trends → Details (framework BI)
+  const report = {
+    generatedAt: new Date().toISOString(),
+    student: {
+      id: studentId,
+      name: student.name,
+      classroom: student.profile?.classroom || null,
+      age: student.profile?.age || null
+    },
+    timeRange,
+
+    // NIVEL 1: Summary cards (top-left, lo más importante)
+    summary: {
+      tier,
+      avgScore: {
+        value: Math.round(metrics.averageScore || 0),
+        rag: scoreEnriched.rag,
+        interpretation: scoreEnriched.interpretation
+      },
+      accuracy: {
+        value: accuracy,
+        rag: accuracyEnriched.rag
+      },
+      engagementScore: {
+        value: results[1].engagementScore,
+        rag: results[1].rag
+      },
+      totalGames: metrics.totalGamesPlayed || 0,
+      bestScore: metrics.bestScore || 0,
+      responseTime: {
+        value: Math.round(metrics.averageResponseTime || 0),
+        rag: responseTimeEnriched.rag
+      }
+    },
+
+    // NIVEL 2: Trends (gráficos de tendencia)
+    trends: {
+      trajectory: results[0].trend,
+      dataPoints: results[0].dataPoints
+    },
+
+    // NIVEL 3: Engagement
+    engagement: {
+      score: results[1].engagementScore,
+      interpretation: results[1].interpretation,
+      components: results[1].components,
+      abandonment: results[1].abandonmentAnalysis
+    }
+  };
+
+  // NIVEL 4: Details (solo en formato detallado)
+  if (format === 'detailed') {
+    report.details = {
+      performanceByContext: results[3]?.series || [],
+      performanceByMechanic: results[4]?.series || [],
+      struggles: results[2]?.moments || [],
+      recentGames: results[0].dataPoints
+    };
+  }
+
+  return report;
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E18 — Reporte completo de la clase
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Genera datos completos de reporte para toda la clase.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.format='summary']
+ * @returns {Promise<Object>}
+ */
+async function getClassroomReport(teacherId, { timeRange = '30d', format = 'summary' } = {}) {
+  // Obtener datos en paralelo
+  const basePromises = [
+    analyticsService.getClassroomSummary(teacherId),
+    analyticsService.getClassroomDistribution(teacherId),
+    analyticsService.getClassroomTrends(teacherId, timeRange),
+    engagementService.getClassroomEngagement(teacherId, {
+      timeRange: timeRange === '7d' ? '30d' : timeRange
+    }),
+    alertsService.getAlertsSummary(teacherId)
+  ];
+
+  if (format === 'detailed') {
+    basePromises.push(
+      contentEffectivenessService.getContentEffectiveness(teacherId, {
+        timeRange: timeRange === '7d' ? '30d' : timeRange
+      })
+    );
+  }
+
+  const results = await Promise.all(basePromises);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    timeRange,
+    overview: {
+      totalStudents: results[3].students.length,
+      totalGames: results[0].totalGames,
+      avgScore: results[0].averageScore,
+      studentsInRisk: results[0].studentsInRisk,
+      classEngagementScore: results[3].classEngagementScore,
+      gamesToday: results[0].gamesToday
+    },
+    distribution: results[1],
+    trends: results[2],
+    topAlerts: results[4],
+    studentSummaries: results[3].students.map(s => ({
+      id: s.studentId,
+      name: s.name,
+      engagementScore: s.engagementScore,
+      completionRate: s.completionRate,
+      gamesPlayed: s.gamesPlayed
+    }))
+  };
+
+  if (format === 'detailed' && results[5]) {
+    report.contentEffectiveness = results[5].items;
+  }
+
+  return report;
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E19 — Datos tabulares para exportación CSV
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Genera datos en formato tabular optimizado para CSV.
+ * Headers en español para el usuario final.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @returns {Promise<Object>} { headers, rows, generatedAt }
+ */
+async function getClassroomExport(teacherId, { timeRange: _timeRange = '30d' } = {}) {
+  const students = await userRepository.find(
+    {
+      createdBy: toObjectId(teacherId),
+      role: 'student',
+      status: 'active'
+    },
+    { select: 'name profile.classroom profile.age studentMetrics' }
+  );
+
+  const headers = [
+    'Nombre',
+    'Aula',
+    'Edad',
+    'Partidas Jugadas',
+    'Puntuación Media',
+    'Mejor Puntuación',
+    'Precisión (%)',
+    'Tiempo Respuesta (ms)',
+    'Nivel',
+    'Última Actividad'
+  ];
+
+  const tierLabels = {
+    risk: 'Riesgo',
+    average: 'Promedio',
+    good: 'Bueno',
+    excellent: 'Excelente'
+  };
+
+  const rows = students.map(s => {
+    const m = s.studentMetrics || {};
+    const accuracy = calcAccuracyRate(m.totalCorrectAnswers, m.totalErrors);
+    const tier = classifyTier(m.averageScore);
+
+    return [
+      s.name,
+      s.profile?.classroom || '',
+      s.profile?.age || '',
+      m.totalGamesPlayed || 0,
+      Math.round(m.averageScore || 0),
+      m.bestScore || 0,
+      accuracy,
+      Math.round(m.averageResponseTime || 0),
+      tierLabels[tier] || tier,
+      m.lastPlayedAt ? new Date(m.lastPlayedAt).toLocaleDateString('es-ES') : 'Sin actividad'
+    ];
+  });
+
+  // Ordenar por nombre
+  rows.sort((a, b) => a[0].localeCompare(b[0], 'es'));
+
+  return {
+    headers,
+    rows,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+module.exports = {
+  getStudentReport,
+  getClassroomReport,
+  getClassroomExport
+};

--- a/backend/src/services/analytics/sessionAnalysisService.js
+++ b/backend/src/services/analytics/sessionAnalysisService.js
@@ -1,0 +1,469 @@
+/**
+ * @fileoverview Servicio de análisis profundo de sesiones de juego.
+ * Desglose ronda-a-ronda, análisis de tarjetas, detección de fatiga
+ * y momentos de dificultad.
+ *
+ * Ver Analytics_Design_Rationale.md § 2.2 para fundamentación pedagógica.
+ *
+ * @module services/analytics/sessionAnalysisService
+ */
+
+const gamePlayRepository = require('../../repositories/gamePlayRepository');
+const userRepository = require('../../repositories/userRepository');
+const { toObjectId, getStartDate, enrichMetric } = require('./analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// E05 — Desglose por rondas de una partida
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene el desglose ronda-a-ronda de una partida con indicador de fatiga.
+ * Los datos se extraen del array events[] del GamePlay (no requiere aggregation).
+ *
+ * @param {string} gameplayId - ID del GamePlay
+ * @returns {Promise<Object>} { gameplayId, totalRounds, rounds, fatigueIndicator }
+ */
+async function getGameplayRounds(gameplayId) {
+  const gameplay = await gamePlayRepository.findById(gameplayId, {
+    select: 'events currentRound score metrics status'
+  });
+
+  if (!gameplay) {
+    const { NotFoundError } = require('../../utils/errors');
+    throw new NotFoundError('Partida no encontrada');
+  }
+
+  // Agrupar eventos por ronda
+  const roundsMap = {};
+  for (const event of gameplay.events) {
+    const rn = event.roundNumber;
+    if (!roundsMap[rn]) {
+      roundsMap[rn] = { events: [], scoreChange: 0 };
+    }
+
+    roundsMap[rn].events.push({
+      eventType: event.eventType,
+      timeElapsed: event.timeElapsed || 0,
+      cardUid: event.cardUid || null,
+      pointsAwarded: event.pointsAwarded || 0
+    });
+
+    if (typeof event.pointsAwarded === 'number') {
+      roundsMap[rn].scoreChange += event.pointsAwarded;
+    }
+  }
+
+  // Construir array de rondas
+  const roundNumbers = Object.keys(roundsMap)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  const answerTypes = new Set(['correct', 'error', 'timeout']);
+
+  const rounds = roundNumbers.map(rn => {
+    const round = roundsMap[rn];
+    const answerEvents = round.events.filter(e => answerTypes.has(e.eventType));
+    const responseTimes = answerEvents.filter(e => e.timeElapsed > 0).map(e => e.timeElapsed);
+    const lastAnswer = answerEvents[answerEvents.length - 1];
+
+    return {
+      roundNumber: rn,
+      events: round.events,
+      result: lastAnswer?.eventType || 'unknown',
+      responseTime:
+        responseTimes.length > 0
+          ? Math.round(responseTimes.reduce((a, b) => a + b, 0) / responseTimes.length)
+          : 0,
+      scoreChange: round.scoreChange
+    };
+  });
+
+  // Calcular indicador de fatiga
+  const roundsWithTime = rounds.filter(r => r.responseTime > 0);
+  const fatigueIndicator = {
+    detected: false,
+    avgTimeFirstHalf: 0,
+    avgTimeSecondHalf: 0,
+    slowdownPercent: 0
+  };
+
+  if (roundsWithTime.length >= 4) {
+    const mid = Math.floor(roundsWithTime.length / 2);
+    const firstHalf = roundsWithTime.slice(0, mid);
+    const secondHalf = roundsWithTime.slice(mid);
+
+    const avgFirst = firstHalf.reduce((s, r) => s + r.responseTime, 0) / firstHalf.length;
+    const avgSecond = secondHalf.reduce((s, r) => s + r.responseTime, 0) / secondHalf.length;
+
+    fatigueIndicator.avgTimeFirstHalf = Math.round(avgFirst);
+    fatigueIndicator.avgTimeSecondHalf = Math.round(avgSecond);
+
+    if (avgFirst > 0) {
+      const slowdown = ((avgSecond - avgFirst) / avgFirst) * 100;
+      fatigueIndicator.slowdownPercent = Math.round(slowdown * 10) / 10;
+      fatigueIndicator.detected = slowdown > 20;
+    }
+  }
+
+  // Enriquecer fatiga con RAG e interpretación (framework BI)
+  const fatigueEnriched = enrichMetric('fatigueSlowdown', fatigueIndicator.slowdownPercent);
+  fatigueIndicator.rag = fatigueEnriched.rag;
+  fatigueIndicator.interpretation = fatigueEnriched.interpretation;
+
+  return {
+    gameplayId,
+    totalRounds: rounds.length,
+    rounds,
+    fatigueIndicator
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E06 — Análisis de tarjetas a nivel de clase
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Analiza el rendimiento por tarjeta RFID: tasa de error, dificultad, etc.
+ *
+ * @param {string} teacherId - ID del profesor
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.contextId] - Filtrar por contexto (opcional)
+ * @param {number} [options.limit=20]
+ * @returns {Promise<Object>} { cards, timeRange }
+ */
+async function getCardAnalysis(teacherId, { timeRange = '30d', contextId, limit = 20 } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const matchStage = {
+    'session.createdBy': toObjectId(teacherId),
+    status: 'completed',
+    completedAt: { $gte: startDate }
+  };
+
+  if (contextId) {
+    matchStage['session.contextId'] = toObjectId(contextId);
+  }
+
+  const pipeline = [
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    { $match: matchStage },
+    { $unwind: '$events' },
+    {
+      $match: {
+        'events.eventType': { $in: ['correct', 'error', 'timeout'] },
+        'events.cardUid': { $ne: null }
+      }
+    },
+    {
+      $group: {
+        _id: '$events.cardUid',
+        totalAttempts: { $sum: 1 },
+        errorCount: {
+          $sum: { $cond: [{ $eq: ['$events.eventType', 'error'] }, 1, 0] }
+        },
+        timeoutCount: {
+          $sum: { $cond: [{ $eq: ['$events.eventType', 'timeout'] }, 1, 0] }
+        },
+        correctCount: {
+          $sum: { $cond: [{ $eq: ['$events.eventType', 'correct'] }, 1, 0] }
+        },
+        avgResponseTime: { $avg: '$events.timeElapsed' },
+        uniqueStudents: { $addToSet: '$playerId' },
+        // Capturar expectedValue para saber qué representa esta tarjeta
+        sampleExpectedValue: { $first: '$events.expectedValue' }
+      }
+    },
+    {
+      $project: {
+        cardUid: '$_id',
+        _id: 0,
+        totalAttempts: 1,
+        errorCount: 1,
+        timeoutCount: 1,
+        correctCount: 1,
+        errorRate: {
+          $round: [
+            {
+              $multiply: [
+                { $divide: [{ $add: ['$errorCount', '$timeoutCount'] }, '$totalAttempts'] },
+                100
+              ]
+            },
+            1
+          ]
+        },
+        avgResponseTime: { $round: ['$avgResponseTime', 0] },
+        uniqueStudentsAttempted: { $size: '$uniqueStudents' },
+        difficultyIndex: {
+          $round: [{ $divide: [{ $add: ['$errorCount', '$timeoutCount'] }, '$totalAttempts'] }, 2]
+        },
+        assignedValue: '$sampleExpectedValue'
+      }
+    },
+    { $sort: { errorRate: -1 } },
+    { $limit: limit }
+  ];
+
+  const cards = await gamePlayRepository.aggregate(pipeline);
+
+  return { cards, timeRange };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E07 — Momentos de dificultad (errores consecutivos)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Detecta momentos de dificultad (errores/timeouts consecutivos) de un estudiante.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {number} [options.minConsecutiveErrors=2]
+ * @returns {Promise<Object>} { moments, totalStruggles, avgStruggleLength }
+ */
+async function getStudentStruggles(
+  studentId,
+  { timeRange = '30d', minConsecutiveErrors = 2 } = {}
+) {
+  const startDate = getStartDate(timeRange);
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    { $sort: { completedAt: -1 } },
+    { $limit: 20 },
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    {
+      $lookup: {
+        from: 'game_contexts',
+        localField: 'session.contextId',
+        foreignField: '_id',
+        as: 'context'
+      }
+    },
+    { $unwind: { path: '$context', preserveNullAndEmptyArrays: true } },
+    {
+      $lookup: {
+        from: 'game_mechanics',
+        localField: 'session.mechanicId',
+        foreignField: '_id',
+        as: 'mechanic'
+      }
+    },
+    { $unwind: { path: '$mechanic', preserveNullAndEmptyArrays: true } },
+    {
+      $project: {
+        events: 1,
+        completedAt: 1,
+        contextName: '$context.name',
+        mechanicName: '$mechanic.name'
+      }
+    }
+  ];
+
+  const gameplays = await gamePlayRepository.aggregate(pipeline);
+  const errorTypes = new Set(['error', 'timeout']);
+  const moments = [];
+
+  for (const gp of gameplays) {
+    let consecutiveErrors = 0;
+    let startRound = null;
+
+    for (const event of gp.events) {
+      if (errorTypes.has(event.eventType)) {
+        if (consecutiveErrors === 0) {
+          startRound = event.roundNumber;
+        }
+        consecutiveErrors++;
+      } else if (event.eventType === 'correct') {
+        if (consecutiveErrors >= minConsecutiveErrors) {
+          moments.push({
+            gameplayId: gp._id.toString(),
+            date: gp.completedAt,
+            startRound,
+            endRound: event.roundNumber - 1,
+            consecutiveErrors,
+            contextName: gp.contextName || 'Desconocido',
+            mechanicName: gp.mechanicName || 'Desconocida'
+          });
+        }
+        consecutiveErrors = 0;
+        startRound = null;
+      }
+    }
+
+    // Verificar si la partida terminó en racha de errores
+    if (consecutiveErrors >= minConsecutiveErrors) {
+      const lastEvent = gp.events[gp.events.length - 1];
+      moments.push({
+        gameplayId: gp._id.toString(),
+        date: gp.completedAt,
+        startRound,
+        endRound: lastEvent?.roundNumber || startRound,
+        consecutiveErrors,
+        contextName: gp.contextName || 'Desconocido',
+        mechanicName: gp.mechanicName || 'Desconocida'
+      });
+    }
+  }
+
+  const totalStruggles = moments.length;
+  const avgStruggleLength =
+    totalStruggles > 0
+      ? Math.round(
+          (moments.reduce((sum, m) => sum + m.consecutiveErrors, 0) / totalStruggles) * 10
+        ) / 10
+      : 0;
+
+  return { moments, totalStruggles, avgStruggleLength };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E08 — Indicadores de fatiga agregados de clase
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene indicadores de fatiga agregados para toda la clase.
+ *
+ * @param {string} teacherId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @returns {Promise<Object>} { summary, byStudent }
+ */
+async function getClassroomFatigue(teacherId, { timeRange = '30d' } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  // Obtener estudiantes del profesor
+  const students = await userRepository.find(
+    { createdBy: toObjectId(teacherId), role: 'student', status: 'active' },
+    { select: 'name' }
+  );
+
+  const studentIds = students.map(s => toObjectId(s._id));
+  if (studentIds.length === 0) {
+    return {
+      summary: { averageSlowdownPercent: 0, studentsShowingFatigue: 0, totalStudentsAnalyzed: 0 },
+      byStudent: []
+    };
+  }
+
+  // Obtener partidas completadas con events
+  const pipeline = [
+    {
+      $match: {
+        playerId: { $in: studentIds },
+        status: 'completed',
+        completedAt: { $gte: startDate },
+        'events.4': { $exists: true } // Al menos 5 eventos (para dividir en mitades)
+      }
+    },
+    {
+      $project: {
+        playerId: 1,
+        events: 1
+      }
+    }
+  ];
+
+  const gameplays = await gamePlayRepository.aggregate(pipeline);
+
+  // Calcular fatiga por estudiante
+  const studentMap = new Map(
+    students.map(s => [s._id.toString(), { name: s.name, slowdowns: [] }])
+  );
+
+  for (const gp of gameplays) {
+    const answerEvents = gp.events.filter(
+      e => ['correct', 'error', 'timeout'].includes(e.eventType) && e.timeElapsed > 0
+    );
+
+    if (answerEvents.length < 4) {
+      continue;
+    }
+
+    const mid = Math.floor(answerEvents.length / 2);
+    const firstHalf = answerEvents.slice(0, mid);
+    const secondHalf = answerEvents.slice(mid);
+
+    const avgFirst = firstHalf.reduce((s, e) => s + e.timeElapsed, 0) / firstHalf.length;
+    const avgSecond = secondHalf.reduce((s, e) => s + e.timeElapsed, 0) / secondHalf.length;
+
+    if (avgFirst > 0) {
+      const slowdown = ((avgSecond - avgFirst) / avgFirst) * 100;
+      const sid = gp.playerId.toString();
+      const entry = studentMap.get(sid);
+      if (entry) {
+        entry.slowdowns.push(slowdown);
+      }
+    }
+  }
+
+  // Agregar por estudiante
+  const byStudent = [];
+  let totalSlowdown = 0;
+  let studentsWithFatigue = 0;
+  let studentsAnalyzed = 0;
+
+  for (const [studentId, data] of studentMap) {
+    if (data.slowdowns.length === 0) {
+      continue;
+    }
+
+    studentsAnalyzed++;
+    const avgSlowdown = data.slowdowns.reduce((a, b) => a + b, 0) / data.slowdowns.length;
+    totalSlowdown += avgSlowdown;
+
+    if (avgSlowdown > 20) {
+      studentsWithFatigue++;
+    }
+
+    byStudent.push({
+      studentId,
+      name: data.name,
+      avgSlowdownPercent: Math.round(avgSlowdown * 10) / 10,
+      gamesAnalyzed: data.slowdowns.length
+    });
+  }
+
+  byStudent.sort((a, b) => b.avgSlowdownPercent - a.avgSlowdownPercent);
+
+  return {
+    summary: {
+      averageSlowdownPercent:
+        studentsAnalyzed > 0 ? Math.round((totalSlowdown / studentsAnalyzed) * 10) / 10 : 0,
+      studentsShowingFatigue: studentsWithFatigue,
+      totalStudentsAnalyzed: studentsAnalyzed
+    },
+    byStudent
+  };
+}
+
+module.exports = {
+  getGameplayRounds,
+  getCardAnalysis,
+  getStudentStruggles,
+  getClassroomFatigue
+};

--- a/backend/src/services/analytics/studentTrajectoryService.js
+++ b/backend/src/services/analytics/studentTrajectoryService.js
@@ -1,0 +1,393 @@
+/**
+ * @fileoverview Servicio de trayectoria de aprendizaje del estudiante.
+ * Proporciona análisis longitudinal: progresión temporal, velocidad de mejora,
+ * detección de mesetas y evolución por contexto/mecánica.
+ *
+ * Ver Analytics_Design_Rationale.md § 2.1 para fundamentación pedagógica.
+ *
+ * @module services/analytics/studentTrajectoryService
+ */
+
+const gamePlayRepository = require('../../repositories/gamePlayRepository');
+const {
+  toObjectId,
+  getStartDate,
+  linearRegression,
+  classifyTrend,
+  enrichMetric
+} = require('./analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// E01 — Trayectoria de aprendizaje
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula la granularidad por defecto según el timeRange.
+ * @param {string} timeRange
+ * @returns {string}
+ */
+const defaultGranularity = timeRange => {
+  if (timeRange === '7d') {
+    return 'daily';
+  }
+  if (timeRange === '30d') {
+    return 'weekly';
+  }
+  return 'monthly';
+};
+
+/**
+ * Devuelve el formato $dateToString según la granularidad.
+ * @param {string} granularity
+ * @returns {string}
+ */
+const dateFormat = granularity => {
+  if (granularity === 'daily') {
+    return '%Y-%m-%d';
+  }
+  if (granularity === 'weekly') {
+    return '%G-W%V';
+  }
+  return '%Y-%m';
+};
+
+/**
+ * Obtiene la trayectoria de aprendizaje de un estudiante con tendencia calculada.
+ *
+ * @param {string} studentId - ID del estudiante
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.granularity] - 'daily', 'weekly', 'monthly'
+ * @returns {Promise<Object>} { dataPoints, trend, timeRange, granularity }
+ */
+async function getStudentTrajectory(studentId, { timeRange = '30d', granularity } = {}) {
+  const gran = granularity || defaultGranularity(timeRange);
+  const startDate = getStartDate(timeRange);
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $group: {
+        _id: { $dateToString: { format: dateFormat(gran), date: '$completedAt' } },
+        avgScore: { $avg: '$score' },
+        accuracy: {
+          $avg: {
+            $cond: [
+              { $gt: ['$metrics.totalAttempts', 0] },
+              {
+                $multiply: [
+                  { $divide: ['$metrics.correctAttempts', '$metrics.totalAttempts'] },
+                  100
+                ]
+              },
+              0
+            ]
+          }
+        },
+        gamesPlayed: { $sum: 1 },
+        avgResponseTime: { $avg: '$metrics.averageResponseTime' }
+      }
+    },
+    { $sort: { _id: 1 } }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+
+  const dataPoints = results.map(r => ({
+    period: r._id,
+    avgScore: Math.round(r.avgScore * 10) / 10,
+    accuracy: Math.round(r.accuracy * 10) / 10,
+    gamesPlayed: r.gamesPlayed,
+    avgResponseTime: Math.round(r.avgResponseTime || 0)
+  }));
+
+  // Calcular tendencia con regresión lineal
+  const points = dataPoints.map((dp, i) => ({ x: i, y: dp.avgScore }));
+  const { slope } = linearRegression(points);
+  const { direction, confidence } = classifyTrend(slope, points.length);
+
+  // Enriquecer con RAG e interpretación (framework BI)
+  const slopeRounded = Math.round(slope * 100) / 100;
+  const trendEnriched = enrichMetric('trendSlope', slopeRounded);
+  const latestScore = dataPoints.length > 0 ? dataPoints[dataPoints.length - 1].avgScore : 0;
+  const scoreEnriched = enrichMetric('score', latestScore);
+
+  return {
+    dataPoints,
+    trend: {
+      direction,
+      slope: slopeRounded,
+      confidence,
+      rag: trendEnriched.rag,
+      interpretation: trendEnriched.interpretation
+    },
+    latestScoreRag: scoreEnriched.rag,
+    timeRange,
+    granularity: gran
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E02 — Velocidad de mejora
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Calcula la velocidad de mejora del estudiante en ventanas temporales.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {number} [options.windowDays=7]
+ * @returns {Promise<Object>} { windows, overallVelocity, accelerating }
+ */
+async function getStudentVelocity(studentId, { timeRange = '30d', windowDays = 7 } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $group: {
+        _id: { $dateToString: { format: '%Y-%m-%d', date: '$completedAt' } },
+        avgScore: { $avg: '$score' }
+      }
+    },
+    { $sort: { _id: 1 } }
+  ];
+
+  const dailyData = await gamePlayRepository.aggregate(pipeline);
+
+  if (dailyData.length < 2) {
+    return { windows: [], overallVelocity: 0, accelerating: false };
+  }
+
+  // Agrupar en ventanas de windowDays
+  const windows = [];
+  let windowStart = 0;
+
+  while (windowStart < dailyData.length) {
+    const windowEnd = Math.min(windowStart + windowDays, dailyData.length);
+    const windowSlice = dailyData.slice(windowStart, windowEnd);
+
+    const avgScore = windowSlice.reduce((sum, d) => sum + d.avgScore, 0) / windowSlice.length;
+
+    windows.push({
+      periodStart: windowSlice[0]._id,
+      periodEnd: windowSlice[windowSlice.length - 1]._id,
+      avgScore: Math.round(avgScore * 10) / 10,
+      velocityChange: 0
+    });
+
+    windowStart = windowEnd;
+  }
+
+  // Calcular cambio de velocidad entre ventanas consecutivas
+  for (let i = 1; i < windows.length; i++) {
+    windows[i].velocityChange =
+      Math.round((windows[i].avgScore - windows[i - 1].avgScore) * 10) / 10;
+  }
+
+  // Velocidad global: pendiente de los promedios de ventana
+  const points = windows.map((w, i) => ({ x: i, y: w.avgScore }));
+  const { slope } = linearRegression(points);
+
+  // ¿Está acelerando? Comparar pendiente primera mitad vs segunda mitad
+  const mid = Math.floor(windows.length / 2);
+  const firstHalf = windows.slice(0, mid).map((w, i) => ({ x: i, y: w.avgScore }));
+  const secondHalf = windows.slice(mid).map((w, i) => ({ x: i, y: w.avgScore }));
+  const slopeFirst = linearRegression(firstHalf).slope;
+  const slopeSecond = linearRegression(secondHalf).slope;
+
+  return {
+    windows,
+    overallVelocity: Math.round(slope * 100) / 100,
+    accelerating: slopeSecond > slopeFirst + 0.1
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E03 — Detección de mesetas
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Detecta periodos de estancamiento en el rendimiento del estudiante.
+ * Un plateau es un periodo de minDays días donde la desviación estándar del score es < 5.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {number} [options.minDays=7]
+ * @returns {Promise<Object>} { plateaus, currentlyInPlateau }
+ */
+async function getStudentPlateaus(studentId, { timeRange = '30d', minDays = 7 } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $group: {
+        _id: { $dateToString: { format: '%Y-%m-%d', date: '$completedAt' } },
+        avgScore: { $avg: '$score' },
+        gamesPlayed: { $sum: 1 }
+      }
+    },
+    { $sort: { _id: 1 } }
+  ];
+
+  const dailyData = await gamePlayRepository.aggregate(pipeline);
+
+  const plateaus = [];
+  const SCORE_VARIATION_THRESHOLD = 5;
+
+  // Ventana deslizante para detectar periodos de baja variación
+  for (let start = 0; start <= dailyData.length - minDays; start++) {
+    const window = dailyData.slice(start, start + minDays);
+    const scores = window.map(d => d.avgScore);
+    const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+    const variance = scores.reduce((sum, s) => sum + (s - mean) ** 2, 0) / scores.length;
+    const stdDev = Math.sqrt(variance);
+
+    if (stdDev < SCORE_VARIATION_THRESHOLD) {
+      const startDate2 = window[0]._id;
+      const endDate = window[window.length - 1]._id;
+
+      // Evitar duplicar plateaus solapados: fusionar con el anterior si se solapan
+      const lastPlateau = plateaus[plateaus.length - 1];
+      if (lastPlateau && lastPlateau.endDate >= startDate2) {
+        lastPlateau.endDate = endDate;
+        lastPlateau.durationDays =
+          Math.floor(
+            (new Date(endDate) - new Date(lastPlateau.startDate)) / (1000 * 60 * 60 * 24)
+          ) + 1;
+        lastPlateau.avgScoreDuringPlateau =
+          Math.round(((lastPlateau.avgScoreDuringPlateau + mean) / 2) * 10) / 10;
+      } else {
+        plateaus.push({
+          startDate: startDate2,
+          endDate,
+          durationDays: minDays,
+          avgScoreDuringPlateau: Math.round(mean * 10) / 10,
+          gamesPlayed: window.reduce((sum, d) => sum + d.gamesPlayed, 0)
+        });
+      }
+    }
+  }
+
+  // ¿Está actualmente en plateau?
+  const lastDays = dailyData.slice(-minDays);
+  let currentlyInPlateau = false;
+  if (lastDays.length >= minDays) {
+    const scores = lastDays.map(d => d.avgScore);
+    const mean = scores.reduce((a, b) => a + b, 0) / scores.length;
+    const variance = scores.reduce((sum, s) => sum + (s - mean) ** 2, 0) / scores.length;
+    currentlyInPlateau = Math.sqrt(variance) < SCORE_VARIATION_THRESHOLD;
+  }
+
+  return { plateaus, currentlyInPlateau };
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// E04 — Evolución por contexto/mecánica
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Obtiene la evolución del rendimiento desglosada por contexto o mecánica.
+ *
+ * @param {string} studentId
+ * @param {Object} options
+ * @param {string} [options.timeRange='30d']
+ * @param {string} [options.groupBy='context'] - 'context' o 'mechanic'
+ * @returns {Promise<Object>} { series, groupBy, timeRange }
+ */
+async function getStudentEvolution(studentId, { timeRange = '30d', groupBy = 'context' } = {}) {
+  const startDate = getStartDate(timeRange);
+
+  const lookupCollection = groupBy === 'context' ? 'game_contexts' : 'game_mechanics';
+  const lookupField = groupBy === 'context' ? 'session.contextId' : 'session.mechanicId';
+
+  const pipeline = [
+    {
+      $match: {
+        playerId: toObjectId(studentId),
+        status: 'completed',
+        completedAt: { $gte: startDate }
+      }
+    },
+    {
+      $lookup: {
+        from: 'game_sessions',
+        localField: 'sessionId',
+        foreignField: '_id',
+        as: 'session'
+      }
+    },
+    { $unwind: '$session' },
+    {
+      $lookup: {
+        from: lookupCollection,
+        localField: lookupField,
+        foreignField: '_id',
+        as: 'groupEntity'
+      }
+    },
+    { $unwind: '$groupEntity' },
+    {
+      $group: {
+        _id: {
+          entityId: '$groupEntity._id',
+          entityName: '$groupEntity.name',
+          week: { $dateToString: { format: '%G-W%V', date: '$completedAt' } }
+        },
+        avgScore: { $avg: '$score' },
+        gamesPlayed: { $sum: 1 }
+      }
+    },
+    { $sort: { '_id.week': 1 } },
+    {
+      $group: {
+        _id: { entityId: '$_id.entityId', entityName: '$_id.entityName' },
+        dataPoints: {
+          $push: {
+            date: '$_id.week',
+            avgScore: { $round: ['$avgScore', 1] },
+            gamesPlayed: '$gamesPlayed'
+          }
+        }
+      }
+    }
+  ];
+
+  const results = await gamePlayRepository.aggregate(pipeline);
+
+  const series = results.map(r => ({
+    name: r._id.entityName,
+    id: r._id.entityId.toString(),
+    dataPoints: r.dataPoints
+  }));
+
+  return { series, groupBy, timeRange };
+}
+
+module.exports = {
+  getStudentTrajectory,
+  getStudentVelocity,
+  getStudentPlateaus,
+  getStudentEvolution
+};

--- a/backend/src/services/gameEngine.js
+++ b/backend/src/services/gameEngine.js
@@ -8,6 +8,7 @@
 const logger = require('../utils/logger').child({ component: 'gameEngine' });
 const gamePlayRepository = require('../repositories/gamePlayRepository');
 const gameSessionRepository = require('../repositories/gameSessionRepository');
+const userRepository = require('../repositories/userRepository');
 const redisService = require('./redisService');
 const { recalculateSessionStatusFromPlays } = require('./sessionStatusService');
 const { getMechanicStrategy } = require('../strategies/mechanics');
@@ -185,8 +186,7 @@ class GameEngine {
       });
 
       await this.processInBatches(abandonedPlays, async playId => {
-        await this.endPlay(playId);
-        this.metrics.totalPlaysCancelled++;
+        await this.endPlay(playId, { abandoned: true });
       });
     }
 
@@ -554,20 +554,26 @@ class GameEngine {
    * 3. Emite el evento 'game_over' al cliente
    * 4. Libera las tarjetas bloqueadas
    * 5. Elimina la partida de la memoria activa
-   * 6. Actualiza métricas
+   * 6. Actualiza métricas del alumno
    *
    * @async
    * @param {string} playId - ID de la partida a finalizar
+   * @param {Object} [options] - Opciones de finalización
+   * @param {boolean} [options.abandoned=false] - Si true, marca la partida como abandonada
+   *   (por timeout de inactividad) en vez de completada. Las partidas abandonadas no
+   *   contribuyen al averageScore del alumno pero sí se registran en totalAbandonedGames.
    * @returns {Promise<void>}
    * @emits game_over - Con puntuación final y métricas
    */
-  async endPlay(playId) {
+  async endPlay(playId, { abandoned = false } = {}) {
     const playState = this.activePlays.get(playId);
     if (!playState) {
       return;
     }
 
-    logger.info(`Finalizando partida ${playId}...`);
+    logger.info(
+      `Finalizando partida ${playId}${abandoned ? ' (abandonada por inactividad)' : ''}...`
+    );
 
     // 1. Limpiar timers pendientes
     if (playState.roundTimer) {
@@ -584,20 +590,57 @@ class GameEngine {
     try {
       const playDuration = Date.now() - playState.createdAt;
 
-      await playState.playDoc.complete(); // Llama al método .complete() del modelo
+      if (abandoned) {
+        // Partida abandonada: marcar status y registrar evento
+        playState.playDoc.status = 'abandoned';
+        playState.playDoc.completedAt = new Date();
+        playState.playDoc.metrics.completionTime = playDuration;
+        playState.playDoc.events.push({
+          timestamp: new Date(),
+          eventType: 'server_restart',
+          roundNumber: playState.playDoc.currentRound,
+          pointsAwarded: 0
+        });
+        await playState.playDoc.save();
+
+        // Registrar abandono en métricas del alumno (no afecta averageScore)
+        const player = await userRepository.findById(playState.playDoc.playerId);
+        if (player) {
+          await player.recordAbandonedGame();
+        }
+
+        this.metrics.totalPlaysCancelled++;
+      } else {
+        // Partida completada normalmente
+        await playState.playDoc.complete();
+
+        // Actualizar métricas del alumno con todos los datos
+        const player = await userRepository.findById(playState.playDoc.playerId);
+        if (player) {
+          await player.updateStudentMetrics({
+            score: playState.playDoc.score,
+            correctAttempts: playState.playDoc.metrics.correctAttempts,
+            errorAttempts: playState.playDoc.metrics.errorAttempts,
+            timeoutAttempts: playState.playDoc.metrics.timeoutAttempts,
+            averageResponseTime: playState.playDoc.metrics.averageResponseTime
+          });
+        }
+
+        this.metrics.totalPlaysCompleted++;
+        this.metrics.averagePlayDuration =
+          (this.metrics.averagePlayDuration * (this.metrics.totalPlaysCompleted - 1) +
+            playDuration) /
+          this.metrics.totalPlaysCompleted;
+      }
+
       await recalculateSessionStatusFromPlays(playState.playDoc.sessionId);
 
       logger.info(`Partida ${playId} guardada en BD`, {
         playId,
         score: playState.playDoc.score,
+        status: abandoned ? 'abandoned' : 'completed',
         duration: `${(playDuration / 1000).toFixed(2)}s`
       });
-
-      // Actualizar métricas
-      this.metrics.totalPlaysCompleted++;
-      this.metrics.averagePlayDuration =
-        (this.metrics.averagePlayDuration * (this.metrics.totalPlaysCompleted - 1) + playDuration) /
-        this.metrics.totalPlaysCompleted;
     } catch (err) {
       logger.error(`Error al guardar partida final ${playId}: ${err.message}`);
     }
@@ -605,7 +648,8 @@ class GameEngine {
     // 3. Emitir evento final al cliente
     this.io.to(`play_${playId}`).emit('game_over', {
       finalScore: playState.playDoc.score,
-      metrics: playState.playDoc.metrics
+      metrics: playState.playDoc.metrics,
+      abandoned
     });
 
     // 4. Limpiar la memoria

--- a/backend/src/services/gamePlayService.js
+++ b/backend/src/services/gamePlayService.js
@@ -189,6 +189,7 @@ async function completePlay(playId) {
     score: play.score,
     correctAttempts: play.metrics.correctAttempts,
     errorAttempts: play.metrics.errorAttempts,
+    timeoutAttempts: play.metrics.timeoutAttempts,
     averageResponseTime: play.metrics.averageResponseTime
   });
 

--- a/backend/src/validators/analyticsValidator.js
+++ b/backend/src/validators/analyticsValidator.js
@@ -80,7 +80,203 @@ const classroomRankingsQuerySchema = z
   })
   .strict();
 
+// ────────────── Schemas avanzados (Analytics Expansion) ─────────────────
+
+/**
+ * TimeRange extendido con soporte para 90 días.
+ * Los endpoints existentes solo aceptan 7d/30d; los nuevos también aceptan 90d.
+ */
+const extendedTimeRangeQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d', '90d']).optional().default('30d')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/trajectory
+ */
+const trajectoryQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d', '90d']).optional().default('30d'),
+    granularity: z.enum(['daily', 'weekly', 'monthly']).optional()
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/velocity
+ */
+const velocityQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    windowDays: z.coerce.number().int().min(3).max(14).optional().default(7)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/plateaus
+ */
+const plateauQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    minDays: z.coerce.number().int().min(3).max(30).optional().default(7)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/evolution
+ */
+const evolutionQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    groupBy: z.enum(['context', 'mechanic']).optional().default('context')
+  })
+  .strict();
+
+/**
+ * Params para endpoints que reciben un GamePlay ID.
+ */
+const gameplayParamsSchema = z
+  .object({
+    id: objectIdSchema
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/card-analysis
+ */
+const cardAnalysisQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d']).optional().default('30d'),
+    contextId: objectIdSchema.optional(),
+    limit: z.coerce.number().int().min(1).max(50).optional().default(20)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/struggles
+ */
+const strugglesQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d']).optional().default('30d'),
+    minConsecutiveErrors: z.coerce.number().int().min(2).max(5).optional().default(2)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/fatigue
+ */
+const fatigueQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d']).optional().default('30d')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/engagement
+ */
+const engagementQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/engagement
+ */
+const classroomEngagementQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    sort: z
+      .enum(['engagementScore', 'completionRate', 'playFrequency'])
+      .optional()
+      .default('engagementScore'),
+    order: z.enum(['asc', 'desc']).optional().default('desc')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/student/:id/play-patterns
+ */
+const playPatternsQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/content-effectiveness
+ */
+const contentEffectivenessQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    groupBy: z.enum(['context', 'mechanic']).optional().default('context')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/card-difficulty
+ */
+const cardDifficultyQuerySchema = z
+  .object({
+    timeRange: z.enum(['30d', '90d']).optional().default('30d'),
+    contextId: objectIdSchema.optional(),
+    threshold: z.coerce.number().min(10).max(90).optional().default(40)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/classroom/learning-curves
+ */
+const learningCurvesQuerySchema = z
+  .object({
+    timeRange: z.enum(['90d']).optional().default('90d'),
+    contextId: objectIdSchema.optional(),
+    mechanicId: objectIdSchema.optional()
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/alerts
+ */
+const alertsQuerySchema = z
+  .object({
+    severity: z.enum(['critical', 'warning', 'info']).optional(),
+    type: z
+      .enum([
+        'declining_performance',
+        'inactivity',
+        'sudden_score_drop',
+        'consistent_timeout',
+        'improving_fast',
+        'plateau_detected',
+        'high_abandonment'
+      ])
+      .optional(),
+    limit: z.coerce.number().int().min(1).max(50).optional().default(20)
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/reports/student/:id y /reports/classroom
+ */
+const reportQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d', '90d']).optional().default('30d'),
+    format: z.enum(['summary', 'detailed']).optional().default('summary')
+  })
+  .strict();
+
+/**
+ * Query params para GET /api/analytics/reports/classroom/export
+ */
+const reportExportQuerySchema = z
+  .object({
+    timeRange: z.enum(['7d', '30d', '90d']).optional().default('30d')
+  })
+  .strict();
+
 module.exports = {
+  // Schemas existentes
   analyticsStudentParamsSchema,
   analyticsTimeRangeQuerySchema,
   classroomStudentsQuerySchema,
@@ -88,5 +284,24 @@ module.exports = {
   classroomTrendsQuerySchema,
   studentSummaryQuerySchema,
   classroomHeatmapQuerySchema,
-  classroomRankingsQuerySchema
+  classroomRankingsQuerySchema,
+  // Schemas avanzados
+  extendedTimeRangeQuerySchema,
+  trajectoryQuerySchema,
+  velocityQuerySchema,
+  plateauQuerySchema,
+  evolutionQuerySchema,
+  gameplayParamsSchema,
+  cardAnalysisQuerySchema,
+  strugglesQuerySchema,
+  fatigueQuerySchema,
+  engagementQuerySchema,
+  classroomEngagementQuerySchema,
+  playPatternsQuerySchema,
+  contentEffectivenessQuerySchema,
+  cardDifficultyQuerySchema,
+  learningCurvesQuerySchema,
+  alertsQuerySchema,
+  reportQuerySchema,
+  reportExportQuerySchema
 };

--- a/backend/src/validators/analyticsValidator.js
+++ b/backend/src/validators/analyticsValidator.js
@@ -30,7 +30,9 @@ const classroomStudentsQuerySchema = z
     sort: z.enum(['name', 'score', 'lastPlayed', 'accuracy']).optional().default('name'),
     order: z.enum(['asc', 'desc']).optional().default('asc'),
     tier: z.enum(['risk', 'average', 'good', 'excellent']).optional(),
-    classroom: z.string().trim().max(50).optional()
+    classroom: z.string().trim().max(50).optional(),
+    contextId: objectIdSchema.optional(),
+    mechanicId: objectIdSchema.optional()
   })
   .strict();
 

--- a/backend/tests/analyticsAdvancedEndpoints.test.js
+++ b/backend/tests/analyticsAdvancedEndpoints.test.js
@@ -1,0 +1,1148 @@
+/**
+ * @fileoverview Tests de integracion para los endpoints avanzados de analytics.
+ * Verifica los endpoints de trayectoria (E01-E04), analisis de sesiones (E05-E08),
+ * engagement (E09-E11), alertas (E15-E16) y reportes (E17-E19).
+ */
+
+const request = require('supertest');
+const { app } = require('../src/server');
+const User = require('../src/models/User');
+const GameContext = require('../src/models/GameContext');
+const GameMechanic = require('../src/models/GameMechanic');
+const GameSession = require('../src/models/GameSession');
+const GamePlay = require('../src/models/GamePlay');
+const CardDeck = require('../src/models/CardDeck');
+
+const fingerprintHeaders = {
+  'User-Agent': 'jest-test',
+  'Accept-Language': 'en',
+  'Accept-Encoding': 'gzip'
+};
+
+const makeAuthHeaders = token => ({
+  Authorization: `Bearer ${token}`,
+  ...fingerprintHeaders
+});
+
+const loginUser = async ({ email, password }) => {
+  const res = await request(app)
+    .post('/api/auth/login')
+    .set(fingerprintHeaders)
+    .send({ email, password });
+  expect(res.statusCode).toBe(200);
+  return res.body.data.accessToken;
+};
+
+describe('Analytics Advanced Endpoints', () => {
+  let token;
+  let otherToken;
+  let teacher;
+  let otherTeacher;
+  const students = [];
+  let context;
+  let mechanic;
+  let deck;
+  let session;
+  let completedPlayId; // ID de una partida completada para tests de rounds
+
+  beforeAll(async () => {
+    // Crear profesor principal
+    teacher = await User.create({
+      name: 'Prof Analytics Adv',
+      email: 'prof-analytics-adv@test.com',
+      password: 'Test1234!',
+      role: 'teacher',
+      accountStatus: 'approved'
+    });
+
+    token = await loginUser({
+      email: 'prof-analytics-adv@test.com',
+      password: 'Test1234!'
+    });
+
+    // Crear segundo profesor para tests de ownership (403)
+    otherTeacher = await User.create({
+      name: 'Prof Otro Adv',
+      email: 'prof-otro-adv@test.com',
+      password: 'Test1234!',
+      role: 'teacher',
+      accountStatus: 'approved'
+    });
+
+    otherToken = await loginUser({
+      email: 'prof-otro-adv@test.com',
+      password: 'Test1234!'
+    });
+
+    // Crear contexto y mecanica
+    context = await GameContext.create({
+      contextId: 'analytics-adv-ctx',
+      name: 'Contexto Analytics Avanzado',
+      description: 'Test context for advanced analytics',
+      createdBy: teacher._id,
+      assets: [
+        { key: 'a1', value: 'val1', display: 'Display 1' },
+        { key: 'a2', value: 'val2', display: 'Display 2' }
+      ]
+    });
+
+    mechanic = await GameMechanic.create({
+      name: 'analytics-adv-mechanic',
+      displayName: 'Analytics Adv Mech',
+      description: 'Test mechanic for advanced analytics'
+    });
+
+    // Crear deck
+    deck = await CardDeck.create({
+      name: 'Analytics Adv Deck',
+      contextId: context._id,
+      createdBy: teacher._id,
+      cardMappings: [
+        { uid: 'AAAA1111', assignedValue: 'val1', displayData: { label: 'Display 1' } },
+        { uid: 'BBBB2222', assignedValue: 'val2', displayData: { label: 'Display 2' } }
+      ]
+    });
+
+    // Crear 5 estudiantes con diferentes perfiles
+    const studentData = [
+      { name: 'Alumno Declive', avgScore: 75, correct: 8, errors: 2 },
+      { name: 'Alumno Estable', avgScore: 55, correct: 6, errors: 4 },
+      { name: 'Alumno Reciente', avgScore: 70, correct: 7, errors: 3 },
+      { name: 'Alumno Sin Datos', avgScore: 0, correct: 0, errors: 0 },
+      { name: 'Alumno Top', avgScore: 90, correct: 9, errors: 1 }
+    ];
+
+    for (const s of studentData) {
+      const student = await User.create({
+        name: s.name,
+        role: 'student',
+        createdBy: teacher._id,
+        status: 'active',
+        profile: { classroom: 'B1' },
+        studentMetrics: {
+          totalGamesPlayed: s.correct + s.errors > 0 ? 10 : 0,
+          totalScore: s.avgScore * 10,
+          averageScore: s.avgScore,
+          bestScore: s.avgScore + 5,
+          totalCorrectAnswers: s.correct,
+          totalErrors: s.errors,
+          averageResponseTime: 2500,
+          lastPlayedAt: s.avgScore > 0 ? new Date() : null
+        }
+      });
+      students.push(student);
+    }
+
+    // Crear sesion
+    session = await GameSession.create({
+      name: 'Sesion Analytics Adv Test',
+      contextId: context._id,
+      mechanicId: mechanic._id,
+      deckId: deck._id,
+      createdBy: teacher._id,
+      status: 'active',
+      config: {
+        numberOfCards: 2,
+        timeLimit: 300,
+        rounds: 5
+      },
+      cardMappings: [
+        { uid: 'AAAA1111', assignedValue: 'val1', displayData: { label: 'Display 1' } },
+        { uid: 'BBBB2222', assignedValue: 'val2', displayData: { label: 'Display 2' } }
+      ]
+    });
+
+    // Crear GamePlays con datos temporales distribuidos
+    const now = new Date();
+    const plays = [];
+
+    // Student 0 (Declive): 15 plays con scores descendentes en 14 dias
+    for (let j = 0; j < 15; j++) {
+      const completedAt = new Date(now);
+      completedAt.setDate(now.getDate() - j);
+      plays.push({
+        sessionId: session._id,
+        playerId: students[0]._id,
+        status: 'completed',
+        score: 80 - j * 3,
+        startedAt: new Date(completedAt.getTime() - 120000),
+        completedAt,
+        metrics: {
+          totalAttempts: 10,
+          correctAttempts: Math.max(3, 8 - j),
+          errorAttempts: Math.min(7, 2 + j),
+          timeoutAttempts: 0,
+          averageResponseTime: 2500 + j * 200,
+          completionTime: 120000
+        },
+        events: [
+          { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 2000 },
+          {
+            roundNumber: 2,
+            cardUid: 'BBBB2222',
+            eventType: j > 7 ? 'error' : 'correct',
+            timeElapsed: 3000 + j * 100
+          },
+          {
+            roundNumber: 3,
+            cardUid: 'AAAA1111',
+            eventType: j > 5 ? 'error' : 'correct',
+            timeElapsed: 3500 + j * 150
+          },
+          {
+            roundNumber: 4,
+            cardUid: 'BBBB2222',
+            eventType: j > 10 ? 'error' : 'correct',
+            timeElapsed: 4000 + j * 200
+          },
+          {
+            roundNumber: 5,
+            cardUid: 'AAAA1111',
+            eventType: j > 12 ? 'error' : 'correct',
+            timeElapsed: 5000 + j * 200
+          }
+        ]
+      });
+    }
+
+    // Student 1 (Estable): 8 plays con score estable ~55
+    for (let j = 0; j < 8; j++) {
+      const completedAt = new Date(now);
+      completedAt.setDate(now.getDate() - j * 2);
+      plays.push({
+        sessionId: session._id,
+        playerId: students[1]._id,
+        status: 'completed',
+        score: 53 + (j % 3) * 2,
+        startedAt: new Date(completedAt.getTime() - 90000),
+        completedAt,
+        metrics: {
+          totalAttempts: 10,
+          correctAttempts: 6,
+          errorAttempts: 4,
+          timeoutAttempts: 0,
+          averageResponseTime: 3000,
+          completionTime: 90000
+        },
+        events: [
+          { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 2500 },
+          { roundNumber: 2, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 3000 },
+          { roundNumber: 3, cardUid: 'AAAA1111', eventType: 'error', timeElapsed: 3500 },
+          { roundNumber: 4, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 2800 },
+          { roundNumber: 5, cardUid: 'AAAA1111', eventType: 'error', timeElapsed: 4000 }
+        ]
+      });
+    }
+
+    // Student 2 (Reciente): 3 plays recientes
+    for (let j = 0; j < 3; j++) {
+      const completedAt = new Date(now);
+      completedAt.setDate(now.getDate() - j);
+      plays.push({
+        sessionId: session._id,
+        playerId: students[2]._id,
+        status: 'completed',
+        score: 68 + j * 3,
+        startedAt: new Date(completedAt.getTime() - 60000),
+        completedAt,
+        metrics: {
+          totalAttempts: 10,
+          correctAttempts: 7,
+          errorAttempts: 3,
+          timeoutAttempts: 0,
+          averageResponseTime: 2200,
+          completionTime: 60000
+        },
+        events: [
+          { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 1800 },
+          { roundNumber: 2, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 2000 },
+          { roundNumber: 3, cardUid: 'AAAA1111', eventType: 'error', timeElapsed: 2500 },
+          { roundNumber: 4, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 2200 },
+          { roundNumber: 5, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 2000 }
+        ]
+      });
+    }
+
+    // Student 3 (Sin Datos): NO plays
+
+    // Student 4 (Top): 5 plays con scores altos
+    for (let j = 0; j < 5; j++) {
+      const completedAt = new Date(now);
+      completedAt.setDate(now.getDate() - j * 2);
+      plays.push({
+        sessionId: session._id,
+        playerId: students[4]._id,
+        status: 'completed',
+        score: 88 + j,
+        startedAt: new Date(completedAt.getTime() - 80000),
+        completedAt,
+        metrics: {
+          totalAttempts: 10,
+          correctAttempts: 9,
+          errorAttempts: 1,
+          timeoutAttempts: 0,
+          averageResponseTime: 1800,
+          completionTime: 80000
+        },
+        events: [
+          { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 1500 },
+          { roundNumber: 2, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 1700 },
+          { roundNumber: 3, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 1800 },
+          { roundNumber: 4, cardUid: 'BBBB2222', eventType: 'correct', timeElapsed: 2000 },
+          { roundNumber: 5, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 1900 }
+        ]
+      });
+    }
+
+    // Student 4 (Top): 2 plays abandonadas
+    plays.push({
+      sessionId: session._id,
+      playerId: students[4]._id,
+      status: 'abandoned',
+      score: 0,
+      startedAt: new Date(now.getTime() - 86400000),
+      metrics: {
+        totalAttempts: 3,
+        correctAttempts: 1,
+        errorAttempts: 2,
+        timeoutAttempts: 0,
+        averageResponseTime: 5000,
+        completionTime: 0
+      },
+      events: [
+        { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'correct', timeElapsed: 3000 },
+        { roundNumber: 2, cardUid: 'BBBB2222', eventType: 'error', timeElapsed: 5000 },
+        { roundNumber: 3, cardUid: 'AAAA1111', eventType: 'error', timeElapsed: 6000 }
+      ]
+    });
+    plays.push({
+      sessionId: session._id,
+      playerId: students[4]._id,
+      status: 'abandoned',
+      score: 0,
+      startedAt: new Date(now.getTime() - 172800000),
+      metrics: {
+        totalAttempts: 2,
+        correctAttempts: 0,
+        errorAttempts: 2,
+        timeoutAttempts: 0,
+        averageResponseTime: 6000,
+        completionTime: 0
+      },
+      events: [
+        { roundNumber: 1, cardUid: 'AAAA1111', eventType: 'error', timeElapsed: 5000 },
+        { roundNumber: 2, cardUid: 'BBBB2222', eventType: 'error', timeElapsed: 7000 }
+      ]
+    });
+
+    const inserted = await GamePlay.insertMany(plays);
+    // Guardar ID de una partida completada (primera del student 0) para tests de rounds
+    completedPlayId = inserted[0]._id.toString();
+  });
+
+  afterAll(async () => {
+    if (session?._id) {
+      await GamePlay.deleteMany({ sessionId: session._id });
+    }
+    if (session?._id) {
+      await GameSession.findByIdAndDelete(session._id);
+    }
+    if (deck?._id) {
+      await CardDeck.findByIdAndDelete(deck._id);
+    }
+    if (mechanic?._id) {
+      await GameMechanic.findByIdAndDelete(mechanic._id);
+    }
+    if (context?._id) {
+      await GameContext.findByIdAndDelete(context._id);
+    }
+    for (const s of students) {
+      await User.findByIdAndDelete(s._id);
+    }
+    if (teacher?._id) {
+      await User.findByIdAndDelete(teacher._id);
+    }
+    if (otherTeacher?._id) {
+      await User.findByIdAndDelete(otherTeacher._id);
+    }
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Trayectoria de aprendizaje (E01-E04)
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('GET /api/analytics/student/:id/trajectory', () => {
+    it('debe retornar trayectoria con dataPoints y trend', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('dataPoints');
+      expect(res.body.data).toHaveProperty('trend');
+      expect(Array.isArray(res.body.data.dataPoints)).toBe(true);
+      expect(res.body.data.trend).toHaveProperty('direction');
+      expect(res.body.data.trend).toHaveProperty('slope');
+      expect(res.body.data.trend).toHaveProperty('confidence');
+    });
+
+    it('debe retornar dataPoints vacio para estudiante sin partidas', async () => {
+      const id = students[3]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.dataPoints).toHaveLength(0);
+    });
+
+    it('debe rechazar timeRange invalido', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory?timeRange=99d`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/trajectory`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/student/:id/velocity', () => {
+    it('debe retornar velocidad de mejora con windows', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/velocity`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('windows');
+      expect(res.body.data).toHaveProperty('overallVelocity');
+      expect(res.body.data).toHaveProperty('accelerating');
+      expect(Array.isArray(res.body.data.windows)).toBe(true);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/velocity`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/velocity`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/student/:id/plateaus', () => {
+    it('debe retornar plateaus y currentlyInPlateau', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/plateaus`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('plateaus');
+      expect(res.body.data).toHaveProperty('currentlyInPlateau');
+      expect(Array.isArray(res.body.data.plateaus)).toBe(true);
+      expect(typeof res.body.data.currentlyInPlateau).toBe('boolean');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/plateaus`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/plateaus`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/student/:id/evolution', () => {
+    it('debe retornar evolucion por contexto por defecto', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/evolution`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('series');
+      expect(res.body.data).toHaveProperty('groupBy');
+      expect(res.body.data).toHaveProperty('timeRange');
+      expect(Array.isArray(res.body.data.series)).toBe(true);
+      expect(res.body.data.groupBy).toBe('context');
+    });
+
+    it('debe aceptar groupBy=mechanic', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/evolution?groupBy=mechanic`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.groupBy).toBe('mechanic');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/evolution`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/evolution`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Analisis de sesiones (E05-E08)
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('GET /api/analytics/gameplay/:id/rounds', () => {
+    it('debe retornar desglose de rondas con fatigueIndicator', async () => {
+      const res = await request(app)
+        .get(`/api/analytics/gameplay/${completedPlayId}/rounds`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('gameplayId');
+      expect(res.body.data).toHaveProperty('totalRounds');
+      expect(res.body.data).toHaveProperty('rounds');
+      expect(res.body.data).toHaveProperty('fatigueIndicator');
+      expect(Array.isArray(res.body.data.rounds)).toBe(true);
+      expect(typeof res.body.data.totalRounds).toBe('number');
+      expect(res.body.data.fatigueIndicator).toHaveProperty('detected');
+    });
+
+    it('debe retornar 404 para gameplay inexistente', async () => {
+      const res = await request(app)
+        .get('/api/analytics/gameplay/507f1f77bcf86cd799439011/rounds')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('debe rechazar ID de formato invalido', async () => {
+      const res = await request(app)
+        .get('/api/analytics/gameplay/not-valid-id/rounds')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get(`/api/analytics/gameplay/${completedPlayId}/rounds`);
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/analytics/classroom/card-analysis', () => {
+    it('debe retornar analisis de tarjetas', async () => {
+      const res = await request(app)
+        .get('/api/analytics/classroom/card-analysis')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('cards');
+      expect(res.body.data).toHaveProperty('timeRange');
+      expect(Array.isArray(res.body.data.cards)).toBe(true);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/classroom/card-analysis');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/analytics/student/:id/struggles', () => {
+    it('debe retornar momentos de dificultad', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/struggles`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('moments');
+      expect(res.body.data).toHaveProperty('totalStruggles');
+      expect(res.body.data).toHaveProperty('avgStruggleLength');
+      expect(Array.isArray(res.body.data.moments)).toBe(true);
+      expect(typeof res.body.data.totalStruggles).toBe('number');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/struggles`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/struggles`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/classroom/fatigue', () => {
+    it('debe retornar indicadores de fatiga de la clase', async () => {
+      const res = await request(app)
+        .get('/api/analytics/classroom/fatigue')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('summary');
+      expect(res.body.data).toHaveProperty('byStudent');
+      expect(res.body.data.summary).toHaveProperty('averageSlowdownPercent');
+      expect(res.body.data.summary).toHaveProperty('studentsShowingFatigue');
+      expect(res.body.data.summary).toHaveProperty('totalStudentsAnalyzed');
+      expect(Array.isArray(res.body.data.byStudent)).toBe(true);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/classroom/fatigue');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Engagement (E09-E11)
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('GET /api/analytics/student/:id/engagement', () => {
+    it('debe retornar engagement con score y componentes', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/engagement`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('engagementScore');
+      expect(res.body.data).toHaveProperty('components');
+      expect(res.body.data).toHaveProperty('abandonmentAnalysis');
+      expect(typeof res.body.data.engagementScore).toBe('number');
+      expect(res.body.data.components).toHaveProperty('playFrequency');
+      expect(res.body.data.components).toHaveProperty('regularity');
+      expect(res.body.data.components).toHaveProperty('completionRate');
+    });
+
+    it('debe retornar engagement basico para estudiante sin partidas', async () => {
+      const id = students[3]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/engagement`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('engagementScore');
+      expect(typeof res.body.data.engagementScore).toBe('number');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/engagement`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/engagement`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/classroom/engagement', () => {
+    it('debe retornar engagement agregado de la clase', async () => {
+      const res = await request(app)
+        .get('/api/analytics/classroom/engagement')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('classEngagementScore');
+      expect(res.body.data).toHaveProperty('classCompletionRate');
+      expect(res.body.data).toHaveProperty('students');
+      expect(res.body.data).toHaveProperty('abandonmentRate');
+      expect(Array.isArray(res.body.data.students)).toBe(true);
+      expect(typeof res.body.data.classEngagementScore).toBe('number');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/classroom/engagement');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/analytics/student/:id/play-patterns', () => {
+    it('debe retornar patrones de juego', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/play-patterns`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('totalGames');
+      expect(res.body.data).toHaveProperty('completedGames');
+      expect(res.body.data).toHaveProperty('abandonedGames');
+      expect(res.body.data).toHaveProperty('sessionsTimeline');
+      expect(typeof res.body.data.totalGames).toBe('number');
+      expect(Array.isArray(res.body.data.sessionsTimeline)).toBe(true);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/student/${id}/play-patterns`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/play-patterns`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Alertas inteligentes (E15-E16)
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('GET /api/analytics/alerts', () => {
+    it('debe retornar alertas como array con summary', async () => {
+      const res = await request(app).get('/api/analytics/alerts').set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('alerts');
+      expect(res.body.data).toHaveProperty('summary');
+      expect(Array.isArray(res.body.data.alerts)).toBe(true);
+      expect(res.body.data.summary).toHaveProperty('critical');
+      expect(res.body.data.summary).toHaveProperty('warning');
+      expect(res.body.data.summary).toHaveProperty('info');
+      expect(res.body.data.summary).toHaveProperty('total');
+    });
+
+    it('debe filtrar por severity', async () => {
+      const res = await request(app)
+        .get('/api/analytics/alerts?severity=warning')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      // Todas las alertas retornadas deben ser de severidad warning
+      for (const alert of res.body.data.alerts) {
+        expect(alert.severity).toBe('warning');
+      }
+    });
+
+    it('debe respetar el parametro limit', async () => {
+      const res = await request(app)
+        .get('/api/analytics/alerts?limit=2')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data.alerts.length).toBeLessThanOrEqual(2);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/alerts');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/analytics/alerts/summary', () => {
+    it('debe retornar resumen con estructura correcta', async () => {
+      const res = await request(app)
+        .get('/api/analytics/alerts/summary')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('total');
+      expect(res.body.data).toHaveProperty('bySeverity');
+      expect(res.body.data).toHaveProperty('byType');
+      expect(res.body.data.bySeverity).toHaveProperty('critical');
+      expect(res.body.data.bySeverity).toHaveProperty('warning');
+      expect(res.body.data.bySeverity).toHaveProperty('info');
+      expect(typeof res.body.data.total).toBe('number');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/alerts/summary');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Reportes y exportacion (E17-E19)
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('GET /api/analytics/reports/student/:id', () => {
+    it('debe retornar reporte del estudiante en formato summary', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/reports/student/${id}`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('generatedAt');
+      expect(res.body.data).toHaveProperty('student');
+      expect(res.body.data).toHaveProperty('summary');
+      expect(res.body.data).toHaveProperty('trends');
+      expect(res.body.data).toHaveProperty('engagement');
+      expect(res.body.data.student).toHaveProperty('name');
+      expect(res.body.data.student).toHaveProperty('id');
+      expect(res.body.data.summary).toHaveProperty('tier');
+      expect(res.body.data.summary).toHaveProperty('avgScore');
+    });
+
+    it('debe retornar reporte detallado con format=detailed', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/reports/student/${id}?format=detailed`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('details');
+      expect(res.body.data.details).toHaveProperty('performanceByContext');
+      expect(res.body.data.details).toHaveProperty('performanceByMechanic');
+      expect(res.body.data.details).toHaveProperty('struggles');
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app).get(`/api/analytics/reports/student/${id}`);
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('debe rechazar acceso de otro profesor', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/reports/student/${id}`)
+        .set(makeAuthHeaders(otherToken));
+
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  describe('GET /api/analytics/reports/classroom', () => {
+    it('debe retornar reporte de la clase', async () => {
+      const res = await request(app)
+        .get('/api/analytics/reports/classroom')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('generatedAt');
+      expect(res.body.data).toHaveProperty('overview');
+      expect(res.body.data).toHaveProperty('distribution');
+      expect(res.body.data).toHaveProperty('trends');
+      expect(res.body.data).toHaveProperty('topAlerts');
+      expect(res.body.data).toHaveProperty('studentSummaries');
+      expect(res.body.data.overview).toHaveProperty('totalStudents');
+      expect(res.body.data.overview).toHaveProperty('avgScore');
+      expect(Array.isArray(res.body.data.studentSummaries)).toBe(true);
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/reports/classroom');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('GET /api/analytics/reports/classroom/export', () => {
+    it('debe retornar datos tabulares con headers y rows', async () => {
+      const res = await request(app)
+        .get('/api/analytics/reports/classroom/export')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('headers');
+      expect(res.body.data).toHaveProperty('rows');
+      expect(res.body.data).toHaveProperty('generatedAt');
+      expect(Array.isArray(res.body.data.headers)).toBe(true);
+      expect(Array.isArray(res.body.data.rows)).toBe(true);
+      expect(res.body.data.headers.length).toBeGreaterThan(0);
+      // Cada fila debe tener la misma cantidad de columnas que headers
+      if (res.body.data.rows.length > 0) {
+        expect(res.body.data.rows[0].length).toBe(res.body.data.headers.length);
+      }
+    });
+
+    it('debe requerir autenticacion', async () => {
+      const res = await request(app).get('/api/analytics/reports/classroom/export');
+
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════
+  // Validacion de estructura detallada de respuestas
+  // ════════════════════════════════════════════════════════════════════
+
+  describe('Estructura detallada de respuestas', () => {
+    it('trajectory: dataPoints deben tener period, avgScore, accuracy, gamesPlayed', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data.dataPoints.length).toBeGreaterThan(0);
+      const point = res.body.data.dataPoints[0];
+      expect(point).toHaveProperty('period');
+      expect(point).toHaveProperty('avgScore');
+      expect(point).toHaveProperty('accuracy');
+      expect(point).toHaveProperty('gamesPlayed');
+      expect(typeof point.avgScore).toBe('number');
+      expect(typeof point.gamesPlayed).toBe('number');
+    });
+
+    it('trajectory: trend debe incluir rag e interpretation', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/trajectory`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const trend = res.body.data.trend;
+      expect(trend).toHaveProperty('rag');
+      expect(trend).toHaveProperty('interpretation');
+      expect(['improving', 'stable', 'declining']).toContain(trend.direction);
+    });
+
+    it('velocity: windows deben tener periodStart, periodEnd, avgScore, velocityChange', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/velocity`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      if (res.body.data.windows.length > 0) {
+        const window = res.body.data.windows[0];
+        expect(window).toHaveProperty('periodStart');
+        expect(window).toHaveProperty('periodEnd');
+        expect(window).toHaveProperty('avgScore');
+        expect(window).toHaveProperty('velocityChange');
+        expect(typeof window.avgScore).toBe('number');
+      }
+    });
+
+    it('rounds: cada ronda debe tener roundNumber, result, responseTime', async () => {
+      const res = await request(app)
+        .get(`/api/analytics/gameplay/${completedPlayId}/rounds`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data.rounds.length).toBeGreaterThan(0);
+      const round = res.body.data.rounds[0];
+      expect(round).toHaveProperty('roundNumber');
+      expect(round).toHaveProperty('result');
+      expect(round).toHaveProperty('responseTime');
+      expect(round).toHaveProperty('events');
+      expect(typeof round.roundNumber).toBe('number');
+    });
+
+    it('rounds: fatigueIndicator debe tener detected, avgTimeFirstHalf, avgTimeSecondHalf', async () => {
+      const res = await request(app)
+        .get(`/api/analytics/gameplay/${completedPlayId}/rounds`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const fi = res.body.data.fatigueIndicator;
+      expect(fi).toHaveProperty('detected');
+      expect(fi).toHaveProperty('avgTimeFirstHalf');
+      expect(fi).toHaveProperty('avgTimeSecondHalf');
+      expect(fi).toHaveProperty('slowdownPercent');
+      expect(typeof fi.detected).toBe('boolean');
+    });
+
+    it('engagement: components deben incluir playFrequency, regularity, completionRate', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/engagement`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const comp = res.body.data.components;
+      expect(comp).toHaveProperty('playFrequency');
+      expect(comp).toHaveProperty('regularity');
+      expect(comp).toHaveProperty('completionRate');
+      expect(comp).toHaveProperty('avgTimeBetweenSessions');
+      expect(comp).toHaveProperty('voluntaryReplays');
+
+      // Cada componente debe tener value y score
+      expect(comp.playFrequency).toHaveProperty('value');
+      expect(comp.playFrequency).toHaveProperty('score');
+      expect(typeof comp.playFrequency.score).toBe('number');
+    });
+
+    it('engagement: abandonmentAnalysis debe tener abandonedGames y abandonmentRate', async () => {
+      const id = students[4]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/engagement`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const ab = res.body.data.abandonmentAnalysis;
+      expect(ab).toHaveProperty('abandonedGames');
+      expect(ab).toHaveProperty('abandonmentRate');
+      expect(typeof ab.abandonedGames).toBe('number');
+      expect(typeof ab.abandonmentRate).toBe('number');
+    });
+
+    it('play-patterns: debe incluir daysSinceLastPlay y favoriteHour', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/student/${id}/play-patterns`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data).toHaveProperty('daysSinceLastPlay');
+      expect(res.body.data).toHaveProperty('favoriteHour');
+      expect(res.body.data).toHaveProperty('favoriteDayOfWeek');
+    });
+
+    it('alerts: cada alerta debe tener id, type, severity, message', async () => {
+      const res = await request(app).get('/api/analytics/alerts').set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      if (res.body.data.alerts.length > 0) {
+        const alert = res.body.data.alerts[0];
+        expect(alert).toHaveProperty('id');
+        expect(alert).toHaveProperty('type');
+        expect(alert).toHaveProperty('severity');
+        expect(alert).toHaveProperty('message');
+        expect(alert).toHaveProperty('recommendation');
+        expect(alert).toHaveProperty('detectedAt');
+        expect(['critical', 'warning', 'info']).toContain(alert.severity);
+      }
+    });
+
+    it('classroom engagement: cada estudiante debe tener engagementScore y completionRate', async () => {
+      const res = await request(app)
+        .get('/api/analytics/classroom/engagement')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      if (res.body.data.students.length > 0) {
+        const s = res.body.data.students[0];
+        expect(s).toHaveProperty('studentId');
+        expect(s).toHaveProperty('name');
+        expect(s).toHaveProperty('engagementScore');
+        expect(s).toHaveProperty('completionRate');
+        expect(s).toHaveProperty('gamesPlayed');
+        expect(typeof s.engagementScore).toBe('number');
+      }
+    });
+
+    it('export: headers deben estar en espanol', async () => {
+      const res = await request(app)
+        .get('/api/analytics/reports/classroom/export')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.data.headers).toContain('Nombre');
+      expect(res.body.data.headers).toContain('Aula');
+      expect(res.body.data.headers).toContain('Nivel');
+    });
+
+    it('student report: summary debe incluir tier, avgScore con rag', async () => {
+      const id = students[0]._id.toString();
+      const res = await request(app)
+        .get(`/api/analytics/reports/student/${id}`)
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const summary = res.body.data.summary;
+      expect(summary).toHaveProperty('tier');
+      expect(summary).toHaveProperty('avgScore');
+      expect(summary).toHaveProperty('accuracy');
+      expect(summary).toHaveProperty('engagementScore');
+      expect(summary).toHaveProperty('totalGames');
+      expect(summary.avgScore).toHaveProperty('value');
+      expect(summary.avgScore).toHaveProperty('rag');
+      expect(summary.avgScore.rag).toHaveProperty('status');
+    });
+
+    it('classroom report: overview debe tener totalStudents y avgScore', async () => {
+      const res = await request(app)
+        .get('/api/analytics/reports/classroom')
+        .set(makeAuthHeaders(token));
+
+      expect(res.statusCode).toBe(200);
+      const overview = res.body.data.overview;
+      expect(overview).toHaveProperty('totalStudents');
+      expect(overview).toHaveProperty('totalGames');
+      expect(overview).toHaveProperty('avgScore');
+      expect(overview).toHaveProperty('classEngagementScore');
+      expect(typeof overview.totalStudents).toBe('number');
+      expect(typeof overview.avgScore).toBe('number');
+    });
+  });
+});

--- a/backend/tests/analyticsHelpers.test.js
+++ b/backend/tests/analyticsHelpers.test.js
@@ -1,0 +1,793 @@
+/**
+ * @fileoverview Tests unitarios para services/analytics/analyticsHelpers.
+ * Verifica constantes exportadas, funciones de clasificación, helpers de fechas,
+ * regresión lineal, generación de alertas y el framework KPI (RAG + interpretaciones).
+ */
+
+const mongoose = require('mongoose');
+
+const {
+  PERFORMANCE_TIERS,
+  ALERT_TYPES,
+  ALERT_SEVERITIES,
+  KPI_DEFINITIONS,
+  RAG,
+  classifyTier,
+  calcAccuracyRate,
+  getStartDate,
+  getPeriodDates,
+  getStartOfToday,
+  toObjectId,
+  teacherSessionStages,
+  linearRegression,
+  classifyTrend,
+  generateAlertId,
+  classifyRAG,
+  generateInterpretation,
+  enrichMetric
+} = require('../src/services/analytics/analyticsHelpers');
+
+// ══════════════════════════════════════════════════════════════════════
+// Constantes exportadas
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — constantes', () => {
+  describe('PERFORMANCE_TIERS', () => {
+    it('debe contener exactamente 4 niveles', () => {
+      expect(PERFORMANCE_TIERS).toHaveLength(4);
+    });
+
+    it('debe cubrir el rango completo 0-100 sin huecos', () => {
+      const tiers = [...PERFORMANCE_TIERS].sort((a, b) => a.min - b.min);
+
+      expect(tiers[0].min).toBe(0);
+      expect(tiers[tiers.length - 1].max).toBe(100);
+
+      for (let i = 1; i < tiers.length; i++) {
+        expect(tiers[i].min).toBe(tiers[i - 1].max + 1);
+      }
+    });
+
+    it('debe tener los nombres de tier esperados', () => {
+      const names = PERFORMANCE_TIERS.map(t => t.tier);
+      expect(names).toEqual(['risk', 'average', 'good', 'excellent']);
+    });
+  });
+
+  describe('ALERT_TYPES', () => {
+    it('debe tener exactamente 7 tipos de alerta', () => {
+      expect(Object.keys(ALERT_TYPES)).toHaveLength(7);
+    });
+
+    it('cada tipo debe tener label y thresholds', () => {
+      for (const [, config] of Object.entries(ALERT_TYPES)) {
+        expect(config).toHaveProperty('label');
+        expect(config).toHaveProperty('thresholds');
+        expect(typeof config.label).toBe('string');
+        expect(typeof config.thresholds).toBe('object');
+      }
+    });
+  });
+
+  describe('ALERT_SEVERITIES', () => {
+    it('debe contener critical, warning e info en orden de urgencia', () => {
+      expect(ALERT_SEVERITIES).toEqual(['critical', 'warning', 'info']);
+    });
+  });
+
+  describe('KPI_DEFINITIONS', () => {
+    it('debe tener exactamente 10 KPIs definidos', () => {
+      expect(Object.keys(KPI_DEFINITIONS)).toHaveLength(10);
+    });
+
+    it('cada KPI debe tener name, unit, direction, green, red, target y formula', () => {
+      for (const [, def] of Object.entries(KPI_DEFINITIONS)) {
+        expect(def).toHaveProperty('name');
+        expect(def).toHaveProperty('unit');
+        expect(def).toHaveProperty('direction');
+        expect(def).toHaveProperty('green');
+        expect(def).toHaveProperty('red');
+        expect(def).toHaveProperty('target');
+        expect(def).toHaveProperty('formula');
+      }
+    });
+
+    it('direction solo puede ser higher_better o lower_better', () => {
+      for (const def of Object.values(KPI_DEFINITIONS)) {
+        expect(['higher_better', 'lower_better']).toContain(def.direction);
+      }
+    });
+  });
+
+  describe('RAG', () => {
+    it('debe tener exactamente RED, AMBER y GREEN', () => {
+      expect(RAG).toEqual({ RED: 'RED', AMBER: 'AMBER', GREEN: 'GREEN' });
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// classifyTier
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — classifyTier', () => {
+  it('debe devolver risk para null', () => {
+    expect(classifyTier(null)).toBe('risk');
+  });
+
+  it('debe devolver risk para undefined', () => {
+    expect(classifyTier(undefined)).toBe('risk');
+  });
+
+  it('debe devolver risk para valores negativos', () => {
+    expect(classifyTier(-1)).toBe('risk');
+    expect(classifyTier(-100)).toBe('risk');
+  });
+
+  it('debe clasificar 0 como risk', () => {
+    expect(classifyTier(0)).toBe('risk');
+  });
+
+  it('debe clasificar 49 como risk (limite superior)', () => {
+    expect(classifyTier(49)).toBe('risk');
+  });
+
+  it('debe clasificar 50 como average (limite inferior)', () => {
+    expect(classifyTier(50)).toBe('average');
+  });
+
+  it('debe clasificar 69 como average (limite superior)', () => {
+    expect(classifyTier(69)).toBe('average');
+  });
+
+  it('debe clasificar 70 como good (limite inferior)', () => {
+    expect(classifyTier(70)).toBe('good');
+  });
+
+  it('debe clasificar 89 como good (limite superior)', () => {
+    expect(classifyTier(89)).toBe('good');
+  });
+
+  it('debe clasificar 90 como excellent (limite inferior)', () => {
+    expect(classifyTier(90)).toBe('excellent');
+  });
+
+  it('debe clasificar 100 como excellent (limite superior)', () => {
+    expect(classifyTier(100)).toBe('excellent');
+  });
+
+  it('debe devolver risk para scores por encima de 100', () => {
+    expect(classifyTier(101)).toBe('risk');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// calcAccuracyRate
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — calcAccuracyRate', () => {
+  it('debe devolver 0 cuando ambos son 0', () => {
+    expect(calcAccuracyRate(0, 0)).toBe(0);
+  });
+
+  it('debe devolver 100 sin errores', () => {
+    expect(calcAccuracyRate(10, 0)).toBe(100);
+  });
+
+  it('debe devolver 0 sin aciertos', () => {
+    expect(calcAccuracyRate(0, 10)).toBe(0);
+  });
+
+  it('debe calcular porcentaje con un decimal', () => {
+    // 7 / (7 + 3) = 0.7 = 70.0
+    expect(calcAccuracyRate(7, 3)).toBeCloseTo(70.0, 1);
+  });
+
+  it('debe redondear correctamente a un decimal', () => {
+    // 1 / 3 = 0.3333... = 33.3%
+    expect(calcAccuracyRate(1, 2)).toBeCloseTo(33.3, 1);
+  });
+
+  it('debe tratar null como 0 en correct', () => {
+    expect(calcAccuracyRate(null, 5)).toBe(0);
+  });
+
+  it('debe tratar undefined como 0 en errors', () => {
+    expect(calcAccuracyRate(5, undefined)).toBe(100);
+  });
+
+  it('debe tratar ambos null como total 0 y devolver 0', () => {
+    expect(calcAccuracyRate(null, null)).toBe(0);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// getStartDate
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — getStartDate', () => {
+  const fixedDate = new Date('2026-04-06T12:00:00.000Z');
+
+  it('debe restar 7 dias para timeRange 7d', () => {
+    const result = getStartDate('7d', fixedDate);
+    const expected = new Date('2026-03-30T12:00:00.000Z');
+
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+
+  it('debe restar 30 dias para timeRange 30d', () => {
+    const result = getStartDate('30d', fixedDate);
+
+    // setDate opera en hora local, lo que puede causar desfase DST en UTC.
+    // Verificamos que el dia del calendario sea correcto.
+    expect(result.getDate()).toBe(7);
+    expect(result.getMonth()).toBe(2); // marzo = 2
+    expect(result.getFullYear()).toBe(2026);
+  });
+
+  it('debe restar 90 dias para timeRange 90d', () => {
+    const result = getStartDate('90d', fixedDate);
+
+    expect(result.getDate()).toBe(6);
+    expect(result.getMonth()).toBe(0); // enero = 0
+    expect(result.getFullYear()).toBe(2026);
+  });
+
+  it('debe usar 30 dias como fallback para timeRange invalido', () => {
+    const result = getStartDate('invalid', fixedDate);
+
+    expect(result.getDate()).toBe(7);
+    expect(result.getMonth()).toBe(2); // marzo = 2
+    expect(result.getFullYear()).toBe(2026);
+  });
+
+  it('debe usar new Date() como from por defecto', () => {
+    const before = new Date();
+    const result = getStartDate('7d');
+    const after = new Date();
+
+    // La fecha resultado debe estar ~7 dias antes de ahora
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    expect(result.getTime()).toBeGreaterThanOrEqual(before.getTime() - sevenDaysMs);
+    expect(result.getTime()).toBeLessThanOrEqual(after.getTime() - sevenDaysMs);
+  });
+
+  it('no debe mutar la fecha original pasada como from', () => {
+    const original = new Date('2026-04-06T12:00:00.000Z');
+    const originalTime = original.getTime();
+
+    getStartDate('7d', original);
+
+    expect(original.getTime()).toBe(originalTime);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// getPeriodDates
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — getPeriodDates', () => {
+  it('debe devolver now, currentStart y previousStart', () => {
+    const result = getPeriodDates('7d');
+
+    expect(result).toHaveProperty('now');
+    expect(result).toHaveProperty('currentStart');
+    expect(result).toHaveProperty('previousStart');
+    expect(result.now).toBeInstanceOf(Date);
+    expect(result.currentStart).toBeInstanceOf(Date);
+    expect(result.previousStart).toBeInstanceOf(Date);
+  });
+
+  it('currentStart debe estar N dias antes de now', () => {
+    const result = getPeriodDates('7d');
+    const diffMs = result.now.getTime() - result.currentStart.getTime();
+    const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+
+    expect(diffDays).toBe(7);
+  });
+
+  it('previousStart debe estar 2N dias antes de now', () => {
+    const result = getPeriodDates('30d');
+    const diffMs = result.now.getTime() - result.previousStart.getTime();
+    const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+
+    expect(diffDays).toBe(60);
+  });
+
+  it('debe usar 30 dias como fallback para timeRange invalido', () => {
+    const result = getPeriodDates('invalid');
+    const diffMs = result.now.getTime() - result.currentStart.getTime();
+    const diffDays = Math.round(diffMs / (24 * 60 * 60 * 1000));
+
+    expect(diffDays).toBe(30);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// getStartOfToday
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — getStartOfToday', () => {
+  it('debe devolver una fecha con hora 00:00:00.000', () => {
+    const result = getStartOfToday();
+
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+
+  it('debe ser del dia actual', () => {
+    const now = new Date();
+    const result = getStartOfToday();
+
+    expect(result.getFullYear()).toBe(now.getFullYear());
+    expect(result.getMonth()).toBe(now.getMonth());
+    expect(result.getDate()).toBe(now.getDate());
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// toObjectId
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — toObjectId', () => {
+  it('debe devolver una instancia de mongoose.Types.ObjectId', () => {
+    const id = '507f1f77bcf86cd799439011';
+    const result = toObjectId(id);
+
+    expect(result).toBeInstanceOf(mongoose.Types.ObjectId);
+  });
+
+  it('debe conservar el valor del string original', () => {
+    const id = '507f1f77bcf86cd799439011';
+    const result = toObjectId(id);
+
+    expect(result.toString()).toBe(id);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// teacherSessionStages
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — teacherSessionStages', () => {
+  it('debe devolver un array de 3 stages', () => {
+    const stages = teacherSessionStages('507f1f77bcf86cd799439011');
+
+    expect(stages).toHaveLength(3);
+  });
+
+  it('el primer stage debe ser $lookup a game_sessions', () => {
+    const stages = teacherSessionStages('507f1f77bcf86cd799439011');
+
+    expect(stages[0]).toHaveProperty('$lookup');
+    expect(stages[0].$lookup.from).toBe('game_sessions');
+    expect(stages[0].$lookup.localField).toBe('sessionId');
+    expect(stages[0].$lookup.foreignField).toBe('_id');
+    expect(stages[0].$lookup.as).toBe('session');
+  });
+
+  it('el segundo stage debe ser $unwind de session', () => {
+    const stages = teacherSessionStages('507f1f77bcf86cd799439011');
+
+    expect(stages[1]).toEqual({ $unwind: '$session' });
+  });
+
+  it('el tercer stage debe ser $match con el teacherId convertido a ObjectId', () => {
+    const teacherId = '507f1f77bcf86cd799439011';
+    const stages = teacherSessionStages(teacherId);
+
+    expect(stages[2]).toHaveProperty('$match');
+    expect(stages[2].$match['session.createdBy']).toBeInstanceOf(mongoose.Types.ObjectId);
+    expect(stages[2].$match['session.createdBy'].toString()).toBe(teacherId);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// linearRegression
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — linearRegression', () => {
+  it('debe devolver slope 0 e intercept 0 para array vacio', () => {
+    const result = linearRegression([]);
+
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(0);
+  });
+
+  it('debe devolver slope 0 e intercept igual a y para un solo punto', () => {
+    const result = linearRegression([{ x: 1, y: 42 }]);
+
+    expect(result.slope).toBe(0);
+    expect(result.intercept).toBe(42);
+  });
+
+  it('debe calcular regresion perfecta (pendiente positiva)', () => {
+    // y = 2x + 1 => slope=2, intercept=1
+    const points = [
+      { x: 0, y: 1 },
+      { x: 1, y: 3 },
+      { x: 2, y: 5 },
+      { x: 3, y: 7 }
+    ];
+    const result = linearRegression(points);
+
+    expect(result.slope).toBeCloseTo(2, 5);
+    expect(result.intercept).toBeCloseTo(1, 5);
+  });
+
+  it('debe calcular regresion perfecta (pendiente negativa)', () => {
+    // y = -3x + 10 => slope=-3, intercept=10
+    const points = [
+      { x: 0, y: 10 },
+      { x: 1, y: 7 },
+      { x: 2, y: 4 },
+      { x: 3, y: 1 }
+    ];
+    const result = linearRegression(points);
+
+    expect(result.slope).toBeCloseTo(-3, 5);
+    expect(result.intercept).toBeCloseTo(10, 5);
+  });
+
+  it('debe manejar puntos con la misma x (denominador 0)', () => {
+    const points = [
+      { x: 5, y: 10 },
+      { x: 5, y: 20 }
+    ];
+    const result = linearRegression(points);
+
+    expect(result.slope).toBe(0);
+    // intercept = promedio de y = 15
+    expect(result.intercept).toBeCloseTo(15, 5);
+  });
+
+  it('debe calcular regresion aproximada con datos ruidosos', () => {
+    const points = [
+      { x: 1, y: 2.1 },
+      { x: 2, y: 3.9 },
+      { x: 3, y: 6.2 },
+      { x: 4, y: 7.8 }
+    ];
+    const result = linearRegression(points);
+
+    // Pendiente aprox ~2, intercept aprox ~0
+    expect(result.slope).toBeGreaterThan(1.5);
+    expect(result.slope).toBeLessThan(2.5);
+  });
+
+  it('debe manejar puntos horizontales (slope = 0)', () => {
+    const points = [
+      { x: 0, y: 5 },
+      { x: 1, y: 5 },
+      { x: 2, y: 5 }
+    ];
+    const result = linearRegression(points);
+
+    expect(result.slope).toBeCloseTo(0, 5);
+    expect(result.intercept).toBeCloseTo(5, 5);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// classifyTrend
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — classifyTrend', () => {
+  describe('direction', () => {
+    it('debe ser improving para slope > 0.5', () => {
+      expect(classifyTrend(0.6, 5).direction).toBe('improving');
+    });
+
+    it('debe ser declining para slope < -0.5', () => {
+      expect(classifyTrend(-0.6, 5).direction).toBe('declining');
+    });
+
+    it('debe ser stable para slope = 0', () => {
+      expect(classifyTrend(0, 5).direction).toBe('stable');
+    });
+
+    it('debe ser stable para slope = 0.5 (limite exacto)', () => {
+      expect(classifyTrend(0.5, 5).direction).toBe('stable');
+    });
+
+    it('debe ser stable para slope = -0.5 (limite exacto)', () => {
+      expect(classifyTrend(-0.5, 5).direction).toBe('stable');
+    });
+  });
+
+  describe('confidence', () => {
+    it('debe ser high con >=7 puntos y |slope| > 1.0', () => {
+      expect(classifyTrend(1.5, 7).confidence).toBe('high');
+    });
+
+    it('debe ser medium con >=4 puntos (slope bajo)', () => {
+      expect(classifyTrend(0.2, 4).confidence).toBe('medium');
+    });
+
+    it('debe ser medium con |slope| > 0.5 (pocos puntos)', () => {
+      expect(classifyTrend(0.6, 2).confidence).toBe('medium');
+    });
+
+    it('debe ser low con pocos puntos y slope bajo', () => {
+      expect(classifyTrend(0.1, 2).confidence).toBe('low');
+    });
+
+    it('debe ser medium (no high) con 7 puntos pero |slope| = 1.0 exacto', () => {
+      // |slope| > 1.0 requiere estrictamente mayor, 1.0 no califica para high
+      expect(classifyTrend(1.0, 7).confidence).toBe('medium');
+    });
+
+    it('debe ser high con slope negativo grande y muchos puntos', () => {
+      expect(classifyTrend(-2.0, 10).confidence).toBe('high');
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// generateAlertId
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — generateAlertId', () => {
+  it('debe devolver un string que empieza con "alert_"', () => {
+    const id = generateAlertId('declining_performance', 'student123', '2026-04-06');
+
+    expect(id).toMatch(/^alert_/);
+  });
+
+  it('debe ser determinista (mismos inputs = mismo output)', () => {
+    const id1 = generateAlertId('inactivity', 'abc', '2026-01-01');
+    const id2 = generateAlertId('inactivity', 'abc', '2026-01-01');
+
+    expect(id1).toBe(id2);
+  });
+
+  it('debe producir IDs distintos para tipos diferentes', () => {
+    const id1 = generateAlertId('inactivity', 'abc', '2026-01-01');
+    const id2 = generateAlertId('declining_performance', 'abc', '2026-01-01');
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it('debe producir IDs distintos para estudiantes diferentes', () => {
+    const id1 = generateAlertId('inactivity', 'student1', '2026-01-01');
+    const id2 = generateAlertId('inactivity', 'student2', '2026-01-01');
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it('debe producir IDs distintos para fechas diferentes', () => {
+    const id1 = generateAlertId('inactivity', 'abc', '2026-01-01');
+    const id2 = generateAlertId('inactivity', 'abc', '2026-01-02');
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it('debe usar la fecha de hoy como fallback cuando no se pasa dateStr', () => {
+    const today = new Date().toISOString().split('T')[0];
+    const idWithDate = generateAlertId('inactivity', 'abc', today);
+    const idWithoutDate = generateAlertId('inactivity', 'abc');
+
+    expect(idWithDate).toBe(idWithoutDate);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// classifyRAG
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — classifyRAG', () => {
+  describe('KPI higher_better (score)', () => {
+    it('debe ser GREEN para valor >= umbral green', () => {
+      const result = classifyRAG('score', 70);
+      expect(result.status).toBe('GREEN');
+    });
+
+    it('debe ser GREEN para valor muy por encima del umbral green', () => {
+      const result = classifyRAG('score', 95);
+      expect(result.status).toBe('GREEN');
+    });
+
+    it('debe ser RED para valor < umbral red', () => {
+      const result = classifyRAG('score', 49);
+      expect(result.status).toBe('RED');
+    });
+
+    it('debe ser AMBER para valor entre red y green', () => {
+      const result = classifyRAG('score', 60);
+      expect(result.status).toBe('AMBER');
+    });
+
+    it('debe ser AMBER en el limite inferior exacto de red (score=50)', () => {
+      // score: red=50. value=50, NOT < 50, so AMBER
+      const result = classifyRAG('score', 50);
+      expect(result.status).toBe('AMBER');
+    });
+  });
+
+  describe('KPI lower_better (abandonmentRate)', () => {
+    it('debe ser GREEN para valor <= umbral green', () => {
+      const result = classifyRAG('abandonmentRate', 10);
+      expect(result.status).toBe('GREEN');
+    });
+
+    it('debe ser GREEN para valor muy bajo', () => {
+      const result = classifyRAG('abandonmentRate', 2);
+      expect(result.status).toBe('GREEN');
+    });
+
+    it('debe ser RED para valor > umbral red', () => {
+      const result = classifyRAG('abandonmentRate', 30);
+      expect(result.status).toBe('RED');
+    });
+
+    it('debe ser AMBER para valor entre green y red', () => {
+      const result = classifyRAG('abandonmentRate', 20);
+      expect(result.status).toBe('AMBER');
+    });
+
+    it('debe ser AMBER en el limite exacto de red (abandonmentRate=25)', () => {
+      // abandonmentRate: red=25. value=25, NOT > 25, so AMBER
+      const result = classifyRAG('abandonmentRate', 25);
+      expect(result.status).toBe('AMBER');
+    });
+  });
+
+  describe('KPI desconocido', () => {
+    it('debe devolver AMBER para un kpiKey inexistente', () => {
+      const result = classifyRAG('unknownKpi', 50);
+      expect(result.status).toBe('AMBER');
+    });
+
+    it('debe devolver thresholds vacio para un kpiKey inexistente', () => {
+      const result = classifyRAG('unknownKpi', 50);
+      expect(result.thresholds).toEqual({});
+    });
+  });
+
+  it('debe incluir thresholds green, red y target en el resultado', () => {
+    const result = classifyRAG('score', 75);
+
+    expect(result.thresholds).toEqual({
+      green: 70,
+      red: 50,
+      target: 75
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// generateInterpretation
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — generateInterpretation', () => {
+  it('debe devolver whatHappened, soWhat y nowWhat', () => {
+    const result = generateInterpretation('score', 75);
+
+    expect(result).toHaveProperty('whatHappened');
+    expect(result).toHaveProperty('soWhat');
+    expect(result).toHaveProperty('nowWhat');
+  });
+
+  it('debe usar "El alumno" como nombre por defecto', () => {
+    const result = generateInterpretation('score', 75);
+
+    expect(result.whatHappened).toContain('El alumno');
+  });
+
+  it('debe usar studentName del contexto cuando se proporciona', () => {
+    const result = generateInterpretation('score', 75, { studentName: 'Maria' });
+
+    expect(result.whatHappened).toContain('Maria');
+  });
+
+  it('debe redondear el valor a 1 decimal', () => {
+    const result = generateInterpretation('score', 75.456);
+
+    // 75.456 -> 75.5
+    expect(result.whatHappened).toContain('75.5');
+  });
+
+  it('debe generar interpretacion distinta para GREEN y RED del mismo KPI', () => {
+    const greenResult = generateInterpretation('score', 90);
+    const redResult = generateInterpretation('score', 30);
+
+    expect(greenResult.soWhat).not.toBe(redResult.soWhat);
+    expect(greenResult.nowWhat).not.toBe(redResult.nowWhat);
+  });
+
+  it('debe devolver fallback para KPI desconocido', () => {
+    const result = generateInterpretation('unknownKpi', 42);
+
+    expect(result.whatHappened).toContain('42');
+    expect(result.soWhat).toBe('');
+    expect(result.nowWhat).toBe('');
+  });
+
+  it('debe generar interpretacion para accuracy GREEN', () => {
+    const result = generateInterpretation('accuracy', 80);
+
+    expect(result.whatHappened).toContain('80');
+    expect(result.soWhat).toBeTruthy();
+    expect(result.nowWhat).toBeTruthy();
+  });
+
+  it('debe generar interpretacion para responseTime (convierte ms a s)', () => {
+    const result = generateInterpretation('responseTime', 3000);
+
+    // 3000ms = 3 segundos
+    expect(result.whatHappened).toContain('3');
+    expect(result.whatHappened.toLowerCase()).toContain('segundo');
+  });
+
+  it('debe generar interpretacion para abandonmentRate RED', () => {
+    const result = generateInterpretation('abandonmentRate', 30);
+
+    expect(result.soWhat.toLowerCase()).toContain('abandono');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// enrichMetric
+// ══════════════════════════════════════════════════════════════════════
+
+describe('analyticsHelpers — enrichMetric', () => {
+  it('debe devolver value, rag, interpretation y kpiMeta', () => {
+    const result = enrichMetric('score', 75);
+
+    expect(result).toHaveProperty('value');
+    expect(result).toHaveProperty('rag');
+    expect(result).toHaveProperty('interpretation');
+    expect(result).toHaveProperty('kpiMeta');
+  });
+
+  it('debe redondear value a 1 decimal', () => {
+    const result = enrichMetric('score', 75.456);
+
+    expect(result.value).toBeCloseTo(75.5, 1);
+  });
+
+  it('rag debe contener status y thresholds', () => {
+    const result = enrichMetric('score', 75);
+
+    expect(result.rag).toHaveProperty('status');
+    expect(result.rag).toHaveProperty('thresholds');
+    expect(result.rag.status).toBe('GREEN');
+  });
+
+  it('interpretation debe tener whatHappened, soWhat y nowWhat', () => {
+    const result = enrichMetric('score', 75);
+
+    expect(result.interpretation).toHaveProperty('whatHappened');
+    expect(result.interpretation).toHaveProperty('soWhat');
+    expect(result.interpretation).toHaveProperty('nowWhat');
+  });
+
+  it('kpiMeta debe tener name, unit, target y formula para KPI conocido', () => {
+    const result = enrichMetric('score', 75);
+
+    expect(result.kpiMeta).toHaveProperty('name');
+    expect(result.kpiMeta).toHaveProperty('unit');
+    expect(result.kpiMeta).toHaveProperty('target');
+    expect(result.kpiMeta).toHaveProperty('formula');
+  });
+
+  it('kpiMeta debe ser null para KPI desconocido', () => {
+    const result = enrichMetric('unknownKpi', 50);
+
+    expect(result.kpiMeta).toBeNull();
+  });
+
+  it('debe pasar el contexto a generateInterpretation', () => {
+    const result = enrichMetric('score', 75, { studentName: 'Carlos' });
+
+    expect(result.interpretation.whatHappened).toContain('Carlos');
+  });
+
+  it('debe manejar value no numerico sin romper', () => {
+    const result = enrichMetric('score', 'abc');
+
+    expect(result.value).toBe('abc');
+  });
+});

--- a/documentation/Sprint5_Tareas.md
+++ b/documentation/Sprint5_Tareas.md
@@ -172,7 +172,7 @@ El dashboard actual depende de 3 endpoints (`/classroom/summary`, `/classroom/co
 
 ---
 
-### T-602: 📊 Dashboard — Eliminar datos mock y conectar datos reales 📋
+### T-602: 📊 Dashboard — Eliminar datos mock y conectar datos reales ✅
 
 **Prioridad:** P0 | **Tamaño:** M (4-8h) | **Dependencias:** T-601
 **Origen:** StudentsList usa mock hardcoded, DistributionChart recibe null, trends son strings fijos
@@ -212,17 +212,17 @@ Tres componentes del dashboard muestran datos ficticios en producción, invalida
 
 **Criterios de Aceptación:**
 
-- [ ] `StudentsList` muestra estudiantes reales del profesor autenticado
-- [ ] `DistributionChart` muestra distribución real de rendimiento
-- [ ] StatCards muestran trends calculados (comparación período actual vs anterior)
-- [ ] Zero datos mock/hardcodeados en el dashboard
-- [ ] Click en estudiante navega a su perfil
-- [ ] Loading states (skeleton) durante carga de nuevos endpoints
-- [ ] `npm test` y `npm run build` pasan
+- [x] `StudentsList` muestra estudiantes reales del profesor autenticado
+- [x] `DistributionChart` muestra distribución real de rendimiento
+- [x] StatCards muestran trends calculados (comparación período actual vs anterior)
+- [x] Zero datos mock/hardcodeados en el dashboard
+- [x] Click en estudiante navega a su perfil
+- [x] Loading states (skeleton) durante carga de nuevos endpoints
+- [x] `npm test` y `npm run build` pasan
 
 ---
 
-### T-603: 📊 Nueva página — Perfil Individual de Estudiante (con comparativa de clase) 📋
+### T-603: 📊 Nueva página — Perfil Individual de Estudiante (con comparativa de clase) ✅
 
 **Consolida:** T-603 + T-620
 **Prioridad:** P0 | **Tamaño:** XL (> 2 días) | **Dependencias:** T-601
@@ -279,20 +279,20 @@ Crear la página `/students/:studentId` que permita al profesor consultar el pro
 
 **Criterios de Aceptación:**
 
-- [ ] Página accesible en `/students/:studentId` con autenticación
-- [ ] Header muestra nombre, avatar, aula, badge de rendimiento, última actividad
-- [ ] 4-6 KPIs individuales con valores reales y comparativa con clase
-- [ ] Gráfico de progreso temporal funcional con selector 7d/30d
-- [ ] Línea punteada de promedio de clase visible en el gráfico de progreso
-- [ ] Leyenda clara diferenciando alumno vs clase, tooltip muestra ambos valores
-- [ ] Gráfico de rendimiento por contexto con barras coloreadas
-- [ ] Gráfico de rendimiento por mecánica funcional
-- [ ] Historial de partidas recientes con al menos 10 entradas
-- [ ] Sección de fortalezas/debilidades derivada de datos
-- [ ] Skeleton loaders durante carga
-- [ ] Responsive: legible en ≥768px
-- [ ] Navegable desde Dashboard y desde breadcrumb
-- [ ] `npm test` y `npm run build` pasan
+- [x] Página accesible en `/students/:studentId` con autenticación
+- [x] Header muestra nombre, avatar, aula, badge de rendimiento, última actividad
+- [x] 4-6 KPIs individuales con valores reales y comparativa con clase
+- [x] Gráfico de progreso temporal funcional con selector 7d/30d
+- [x] Línea punteada de promedio de clase visible en el gráfico de progreso
+- [x] Leyenda clara diferenciando alumno vs clase, tooltip muestra ambos valores
+- [x] Gráfico de rendimiento por contexto con barras coloreadas
+- [x] Gráfico de rendimiento por mecánica funcional
+- [x] Historial de partidas recientes con al menos 10 entradas
+- [x] Sección de fortalezas/debilidades derivada de datos
+- [x] Skeleton loaders durante carga
+- [x] Responsive: legible en ≥768px
+- [x] Navegable desde Dashboard y desde breadcrumb
+- [x] `npm test` y `npm run build` pasan
 
 ---
 
@@ -697,7 +697,7 @@ Las acciones de pause/resume carecen de rate limiting. Todos los rate limiters u
 
 ---
 
-### T-604: 📊 Dashboard — KPIs expandidos, filtros interactivos, alertas inteligentes y heatmap mejorado 📋
+### T-604: 📊 Dashboard — KPIs expandidos, filtros interactivos, alertas inteligentes y heatmap mejorado ✅
 
 **Consolida:** T-604 + T-605 + T-607 + T-615
 **Prioridad:** P1 | **Tamaño:** XL (> 2 días) | **Dependencias:** T-601, T-602
@@ -743,25 +743,25 @@ Mejora integral del dashboard con: KPIs adicionales, filtros interactivos, siste
 
 **Criterios de Aceptación:**
 
-- [ ] 8 KPIs visibles con datos reales
-- [ ] Filtros de contexto, mecánica y rango de fechas funcionales
-- [ ] Filtros afectan todos los componentes del dashboard
-- [ ] Sección de actividad reciente con partidas reales
-- [ ] Al menos 5 tipos de alerta diferentes derivados de datos
-- [ ] Cada alerta tiene acción directa que navega a contenido relevante
-- [ ] Estado vacío muestra mensaje positivo en vez de `null`
-- [ ] Alertas se generan automáticamente de los datos
-- [ ] Leyenda clara con 3 niveles de dificultad en heatmap
-- [ ] Tooltips con información accionable en heatmap
-- [ ] Visualización intuitiva para personas no técnicas
-- [ ] Cero `<select>` nativos en Dashboard y ChartSection
-- [ ] Accesibilidad mantenida en SelectPremium
-- [ ] Layout responsivo en ≥768px
-- [ ] `npm test` y `npm run build` pasan
+- [x] 8 KPIs visibles con datos reales
+- [x] Filtros de contexto, mecánica y rango de fechas funcionales
+- [x] Filtros afectan todos los componentes del dashboard
+- [x] Sección de actividad reciente con partidas reales
+- [x] Al menos 5 tipos de alerta diferentes derivados de datos
+- [x] Cada alerta tiene acción directa que navega a contenido relevante
+- [x] Estado vacío muestra mensaje positivo en vez de `null`
+- [x] Alertas se generan automáticamente de los datos
+- [x] Leyenda clara con 3 niveles de dificultad en heatmap
+- [x] Tooltips con información accionable en heatmap
+- [x] Visualización intuitiva para personas no técnicas
+- [x] Cero `<select>` nativos en Dashboard y ChartSection
+- [x] Accesibilidad mantenida en SelectPremium
+- [x] Layout responsivo en ≥768px
+- [x] `npm test` y `npm run build` pasan
 
 ---
 
-### T-606: 📊 Nueva página — Vista Comparativa de Estudiantes (con exportación CSV y navegación) 📋
+### T-606: 📊 Nueva página — Vista Comparativa de Estudiantes (con exportación CSV y navegación) ✅
 
 **Consolida:** T-606 + T-617 + T-618
 **Prioridad:** P1 | **Tamaño:** XL (> 2 días) | **Dependencias:** T-601, T-603
@@ -800,21 +800,21 @@ Crear la página `/analytics/students` con tabla interactiva de todos los estudi
 
 **Criterios de Aceptación:**
 
-- [ ] Página accesible en `/analytics/students`
-- [ ] Tabla con todos los estudiantes y métricas reales
-- [ ] Ordenable por todas las columnas
-- [ ] Filtrable por tier y búsqueda por nombre
-- [ ] Click en estudiante navega a su perfil (T-603)
-- [ ] Resumen visual de distribución de clase
-- [ ] Skeleton loader durante carga
-- [ ] Responsive en ≥768px
-- [ ] Botón "Exportar CSV" visible en vista de estudiantes
-- [ ] CSV generado correctamente con datos reales
-- [ ] Descarga automática del archivo
-- [ ] Sin dependencias externas para CSV
-- [ ] Badge de notificación visible cuando hay alertas
-- [ ] Enlace "Mis Alumnos" funcional en sidebar
-- [ ] `npm test` y `npm run build` pasan
+- [x] Página accesible en `/analytics/students`
+- [x] Tabla con todos los estudiantes y métricas reales
+- [x] Ordenable por todas las columnas
+- [x] Filtrable por tier y búsqueda por nombre
+- [x] Click en estudiante navega a su perfil (T-603)
+- [x] Resumen visual de distribución de clase
+- [x] Skeleton loader durante carga
+- [x] Responsive en ≥768px
+- [x] Botón "Exportar CSV" visible en vista de estudiantes
+- [x] CSV generado correctamente con datos reales
+- [x] Descarga automática del archivo
+- [x] Sin dependencias externas para CSV
+- [x] Badge de notificación visible cuando hay alertas
+- [x] Enlace "Mis Alumnos" funcional en sidebar
+- [x] `npm test` y `npm run build` pasan
 
 ---
 
@@ -1336,7 +1336,7 @@ Crear tres componentes UI reutilizables para mejorar la consistencia visual y de
 - [x] Componente `PageHeader` creado con props flexibles
 - [x] Al menos 3 páginas usan PageHeader — SessionsPage, ContextsPage, CardDecksPage
 - [x] Componente `ErrorState` creado y reutilizable — integrado en CardDecksPage
-- [ ] AlertsPanel muestra estado positivo cuando no hay alertas — pendiente (requiere T-604/T-605)
+- [x] AlertsPanel muestra estado positivo cuando no hay alertas — implementado en T-604
 - [x] Al menos 4 componentes migrados a estados unificados — 6 migrados: CardDecksPage (ErrorState), SessionsPage (ErrorState), ContextsPage (ErrorState), Dashboard (ErrorState), DifficultyHeatmap (EmptyState), StudentProgressChart (EmptyState)
 - [x] Aspecto visual consistente
 - [x] Tokens semánticos usados

--- a/documentation/Sprint5_Tareas.md
+++ b/documentation/Sprint5_Tareas.md
@@ -1366,6 +1366,95 @@ Tarea de **PLANIFICACIÓN** — no implementación. Analizar el archivo, identif
 
 ---
 
+### T-625: 📊 Backend — Endpoints de analytics avanzados (19 endpoints) ✅
+
+**Prioridad:** P0 | **Tamaño:** XL (> 2 días) | **Dependencias:** T-601
+**Origen:** Análisis de necesidades pedagógicas — los profesores necesitan profundidad analítica para entender cómo aprenden los niños individualmente
+
+**Descripción:**
+Expansión mayor del backend de analytics, añadiendo 19 nuevos endpoints organizados en 6 grupos: trayectoria de aprendizaje (4), análisis profundo de sesiones (4), métricas de engagement (3), efectividad de contenido (3), alertas inteligentes server-side (2) y datos para reportes/exportación (3). Se descompone la funcionalidad en sub-servicios temáticos bajo `services/analytics/` sin modificar el servicio existente (zero regresión). Documentación completa en `backend/docs/Analytics_Design_Rationale.md` y ADR-026.
+
+**Sub-tareas:**
+
+1. **Documentación y arquitectura:**
+   - Crear `backend/docs/Analytics_Design_Rationale.md` con justificación pedagógica y de BI
+   - ADR-026 en `Architecture_Decisions.md` (descomposición modular del servicio)
+   - Crear estructura `services/analytics/` con helpers compartidos
+
+2. **Trayectoria de aprendizaje (E01-E04):**
+   - `GET /student/:id/trajectory` — progresión temporal con tendencia (regresión lineal)
+   - `GET /student/:id/velocity` — velocidad de mejora en ventanas temporales
+   - `GET /student/:id/plateaus` — detección de mesetas (estancamiento)
+   - `GET /student/:id/evolution` — evolución por contexto o mecánica
+
+3. **Análisis de sesiones (E05-E08):**
+   - `GET /gameplay/:id/rounds` — desglose ronda-a-ronda con detección de fatiga
+   - `GET /classroom/card-analysis` — análisis de tarjetas: tasa de error, dificultad
+   - `GET /student/:id/struggles` — momentos de dificultad (errores consecutivos)
+   - `GET /classroom/fatigue` — indicadores de fatiga agregados por clase
+
+4. **Engagement (E09-E11):**
+   - `GET /student/:id/engagement` — score de engagement (5 componentes ponderados)
+   - `GET /classroom/engagement` — engagement agregado de la clase con ranking
+   - `GET /student/:id/play-patterns` — patrones de juego (horarios, timeline)
+
+5. **Efectividad de contenido (E12-E14):**
+   - `GET /classroom/content-effectiveness` — qué contextos producen mejor aprendizaje
+   - `GET /classroom/card-difficulty` — tarjetas problemáticas (tasa error > umbral)
+   - `GET /classroom/learning-curves` — curvas de aprendizaje por contenido
+
+6. **Alertas inteligentes (E15-E16):**
+   - `GET /alerts` — alertas computadas server-side con severidad y recomendaciones
+   - `GET /alerts/summary` — resumen de alertas para badges del sidebar
+   - 7 tipos: declining, inactivity, score_drop, timeout, improving, plateau, abandonment
+
+7. **Reportes y exportación (E17-E19):**
+   - `GET /reports/student/:id` — reporte completo de estudiante (orquesta sub-servicios)
+   - `GET /reports/classroom` — reporte de clase completo
+   - `GET /reports/classroom/export` — datos tabulares para CSV
+
+8. **Infraestructura:**
+   - 18 nuevos validadores Zod (incluyendo timeRange extendido a 90d)
+   - 2 nuevos índices MongoDB (GamePlay, GameSession)
+   - Método `aggregate` en gameSessionRepository
+   - Caching diferenciado (300s datos, 600s alertas/reportes)
+
+**Archivos Creados:**
+- `backend/src/services/analytics/analyticsHelpers.js`
+- `backend/src/services/analytics/alertsService.js`
+- `backend/src/services/analytics/studentTrajectoryService.js`
+- `backend/src/services/analytics/sessionAnalysisService.js`
+- `backend/src/services/analytics/engagementService.js`
+- `backend/src/services/analytics/contentEffectivenessService.js`
+- `backend/src/services/analytics/reportDataService.js`
+- `backend/src/services/analytics/index.js`
+- `backend/src/controllers/analyticsAdvancedController.js`
+- `backend/docs/Analytics_Design_Rationale.md`
+
+**Archivos Modificados:**
+- `backend/src/routes/analytics.js` — 19 nuevas rutas
+- `backend/src/validators/analyticsValidator.js` — 18 nuevos schemas
+- `backend/src/models/GamePlay.js` — 1 nuevo índice
+- `backend/src/models/GameSession.js` — 1 nuevo índice
+- `backend/src/repositories/gameSessionRepository.js` — método aggregate
+- `backend/docs/Architecture_Decisions.md` — ADR-026
+
+**Criterios de Aceptación:**
+
+- [x] 19 nuevos endpoints implementados bajo `/api/analytics/`
+- [x] Todos requieren autenticación y rol teacher/super_admin
+- [x] Validación Zod estricta en todos los endpoints
+- [x] Sub-servicios organizados por dominio en `services/analytics/`
+- [x] `analyticsService.js` original NO modificado (zero regresión)
+- [x] `analyticsController.js` original NO modificado
+- [x] Documento de diseño con justificación pedagógica y de BI
+- [x] ADR-026 documentando la decisión de descomposición
+- [x] Caching Redis en endpoints costosos
+- [x] `npm run lint` sin errores
+- [x] `npm test` — 695 tests pasando sin regresiones
+
+---
+
 ### T-616: 📊 Onboarding — Guía de primer uso para profesores 📋
 
 **Prioridad:** P3 | **Tamaño:** M (4-8h) | **Dependencias:** T-602

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,11 @@ const DeckEditPage = lazy(() => import('./pages/DeckEditPage'));
 const ContextsPage = lazy(() => import('./pages/ContextsPage'));
 const ContextDetailPage = lazy(() => import('./pages/ContextDetailPage'));
 
+// Analytics pages
+const StudentProfile = lazy(() => import('./pages/StudentProfile'));
+const StudentsAnalytics = lazy(() => import('./pages/StudentsAnalytics'));
+const InsightsReports = lazy(() => import('./pages/InsightsReports'));
+
 // Auth pages
 const Login = lazy(() => import('./pages/Login'));
 const Register = lazy(() => import('./pages/Register'));
@@ -134,6 +139,9 @@ function AppContent() {
           <Route path="create-session" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><CreateSession /></SuspenseWrapper></RequireRole>} />
           <Route path="board-setup" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><BoardSetup /></SuspenseWrapper></RequireRole>} />
           <Route path="board-setup/:sessionId" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><BoardSetup /></SuspenseWrapper></RequireRole>} />
+          <Route path="students/:studentId" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><StudentProfile /></SuspenseWrapper></RequireRole>} />
+          <Route path="analytics/students" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><StudentsAnalytics /></SuspenseWrapper></RequireRole>} />
+          <Route path="analytics/insights" element={<RequireRole roles="teacher" redirectTo={ROUTES.ADMIN_APPROVALS}><SuspenseWrapper><InsightsReports /></SuspenseWrapper></RequireRole>} />
 
           {/* Ruta exclusiva de admin */}
           <Route path="students/transfer" element={

--- a/frontend/src/components/analytics/ActivityHeatmap.jsx
+++ b/frontend/src/components/analytics/ActivityHeatmap.jsx
@@ -1,0 +1,148 @@
+import { memo, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Dias de la semana en espanol (abreviados)
+ */
+const DAYS = ['Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab', 'Dom'];
+
+/**
+ * Horas del dia a mostrar (reducido para legibilidad)
+ */
+const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
+
+/**
+ * Calcula la intensidad de color basada en el valor relativo al maximo
+ * @param {number} value - Numero de partidas en esa celda
+ * @param {number} max - Maximo valor en todo el heatmap
+ * @returns {string} Clase de Tailwind para el color de fondo
+ */
+const getIntensityClass = (value, max) => {
+  if (!value || value === 0) return 'bg-background-surface/30';
+  const ratio = value / max;
+  if (ratio >= 0.75) return 'bg-brand-base/60';
+  if (ratio >= 0.5) return 'bg-brand-base/40';
+  if (ratio >= 0.25) return 'bg-brand-base/25';
+  return 'bg-brand-base/12';
+};
+
+/**
+ * Heatmap de actividad semanal (dia x hora).
+ * Muestra cuando juegan los alumnos — util para planificar sesiones.
+ *
+ * @param {Object} props
+ * @param {Object} props.data - Datos del endpoint /classroom/heatmap
+ *   Formato esperado: { heatmap: [[...hours], ...days] } o { data: [{day, hour, count}] }
+ */
+function ActivityHeatmap({ data }) {
+  const { grid, maxValue } = useMemo(() => {
+    if (!data) return { grid: null, maxValue: 0 };
+
+    let gridData = [];
+    let max = 0;
+
+    // Soportar ambos formatos de respuesta del backend
+    if (Array.isArray(data.heatmap)) {
+      // Formato matriz: heatmap[day][hour] = count
+      gridData = data.heatmap;
+      for (const row of gridData) {
+        for (const val of row) {
+          if (val > max) max = val;
+        }
+      }
+    } else if (Array.isArray(data.data || data)) {
+      // Formato flat: [{day, hour, count}]
+      const flat = data.data || data;
+      gridData = Array.from({ length: 7 }, () => Array(24).fill(0));
+      for (const item of flat) {
+        const d = item.day ?? item.dayOfWeek;
+        const h = item.hour;
+        const c = item.count ?? item.games ?? 0;
+        if (d != null && h != null) {
+          gridData[d][h] = c;
+          if (c > max) max = c;
+        }
+      }
+    }
+
+    return { grid: gridData, maxValue: max };
+  }, [data]);
+
+  if (!grid || maxValue === 0) {
+    return (
+      <GlassCard variant="default" padding="none" className="p-5">
+        <h3 className="text-base font-bold text-text-primary font-display mb-4">Actividad Semanal</h3>
+        <div className="py-6 text-center">
+          <p className="text-sm text-text-muted">No hay datos de actividad disponibles.</p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-bold text-text-primary font-display">Actividad Semanal</h3>
+        <div className="flex items-center gap-2 text-[10px] text-text-muted">
+          <span>Menos</span>
+          <div className="flex gap-0.5">
+            <div className="size-3 rounded-sm bg-background-surface/30" />
+            <div className="size-3 rounded-sm bg-brand-base/12" />
+            <div className="size-3 rounded-sm bg-brand-base/25" />
+            <div className="size-3 rounded-sm bg-brand-base/40" />
+            <div className="size-3 rounded-sm bg-brand-base/60" />
+          </div>
+          <span>Mas</span>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto -mx-2">
+        <div className="min-w-[400px] px-2">
+          {/* Hours header */}
+          <div className="flex gap-0.5 ml-10 mb-1">
+            {HOURS.map(h => (
+              <div key={h} className="flex-1 text-center text-[10px] text-text-muted tabular-nums">
+                {h}h
+              </div>
+            ))}
+          </div>
+
+          {/* Grid rows */}
+          <div className="space-y-0.5" aria-label="Mapa de calor de actividad semanal, horario de 8 a 18 horas, lunes a domingo">
+            {DAYS.map((day, dayIndex) => (
+              <div key={day} className="flex items-center gap-0.5">
+                <span className="w-9 text-right text-[11px] text-text-muted font-medium pr-1">
+                  {day}
+                </span>
+                <div className="flex gap-0.5 flex-1">
+                  {HOURS.map(hour => {
+                    const value = grid[dayIndex]?.[hour] || 0;
+                    return (
+                      <div
+                        key={hour}
+                        className={cn(
+                          "flex-1 aspect-square rounded-sm transition-colors",
+                          getIntensityClass(value, maxValue)
+                        )}
+                        title={`${day} ${hour}:00 — ${value} partidas`}
+                        aria-label={`${day} a las ${hour}: ${value} partidas`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+ActivityHeatmap.propTypes = {
+  data: PropTypes.object,
+};
+
+export default memo(ActivityHeatmap);

--- a/frontend/src/components/analytics/AlertsHub.jsx
+++ b/frontend/src/components/analytics/AlertsHub.jsx
@@ -1,0 +1,416 @@
+import { memo, useMemo, useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import {
+  TrendingDown,
+  Clock,
+  AlertTriangle,
+  Pause,
+  TrendingUp,
+  Minus,
+  XCircle,
+  CheckCircle2,
+  Filter,
+  User,
+  Layers,
+} from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn, listContainerVariants, listItemVariants, DURATION, EASING } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+import SelectPremium from '../ui/SelectPremium';
+import SkeletonShimmer from '../ui/SkeletonShimmer';
+
+/**
+ * Mapeo de tipo de alerta a icono de Lucide.
+ */
+const ALERT_TYPE_ICONS = {
+  declining_performance: TrendingDown,
+  inactivity: Clock,
+  sudden_score_drop: AlertTriangle,
+  consistent_timeout: Pause,
+  improving_fast: TrendingUp,
+  plateau_detected: Minus,
+  high_abandonment: XCircle,
+};
+
+/**
+ * Etiquetas en espanol para cada tipo de alerta.
+ */
+const ALERT_TYPE_LABELS = {
+  declining_performance: 'Caida de rendimiento',
+  inactivity: 'Inactividad',
+  sudden_score_drop: 'Caida brusca',
+  consistent_timeout: 'Timeouts frecuentes',
+  improving_fast: 'Mejora rapida',
+  plateau_detected: 'Estancamiento',
+  high_abandonment: 'Alto abandono',
+};
+
+/**
+ * Estilos por severidad.
+ */
+const SEVERITY_STYLES = {
+  critical: {
+    dot: 'bg-error-base',
+    glow: 'shadow-[0_0_6px_var(--color-error-glow)]',
+    bg: 'bg-error-base/10',
+    border: 'border-error-base/30',
+    text: 'text-error-base',
+    label: 'Criticas',
+  },
+  warning: {
+    dot: 'bg-warning-base',
+    glow: 'shadow-[0_0_6px_var(--color-warning-glow)]',
+    bg: 'bg-warning-base/10',
+    border: 'border-warning-base/30',
+    text: 'text-warning-base',
+    label: 'Warning',
+  },
+  info: {
+    dot: 'bg-info-base',
+    glow: 'shadow-[0_0_6px_var(--color-info-glow)]',
+    bg: 'bg-info-base/10',
+    border: 'border-info-base/30',
+    text: 'text-info-base',
+    label: 'Info',
+  },
+};
+
+/**
+ * Formatea una fecha como texto relativo.
+ */
+function formatRelativeDate(dateStr) {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'Hace un momento';
+  if (diffMins < 60) return `Hace ${diffMins}min`;
+  if (diffHours < 24) return `Hace ${diffHours}h`;
+  if (diffDays < 7) return `Hace ${diffDays}d`;
+  return date.toLocaleDateString('es-ES', { day: 'numeric', month: 'short' });
+}
+
+/**
+ * Tarjeta de contador de severidad.
+ */
+function SeverityCounter({ severity, count }) {
+  const style = SEVERITY_STYLES[severity] || SEVERITY_STYLES.info;
+
+  return (
+    <div className={cn(
+      'rounded-xl border px-4 py-3 flex items-center gap-3',
+      style.bg, style.border
+    )}>
+      <div className={cn('size-3 rounded-full flex-shrink-0', style.dot, style.glow)} />
+      <div>
+        <p className={cn('text-xl font-bold tabular-nums font-display', style.text)}>
+          {count}
+        </p>
+        <p className="text-xs text-text-muted font-medium">{style.label}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Tarjeta individual de alerta.
+ */
+function AlertCard({ alert, shouldReduceMotion }) {
+  const navigate = useNavigate();
+  const severity = SEVERITY_STYLES[alert.severity] || SEVERITY_STYLES.info;
+  const TypeIcon = ALERT_TYPE_ICONS[alert.type] || AlertTriangle;
+  const typeLabel = ALERT_TYPE_LABELS[alert.type] || alert.type;
+  const isPositive = alert.type === 'improving_fast';
+
+  return (
+    <motion.div
+      variants={shouldReduceMotion ? {} : listItemVariants}
+      className={cn(
+        'rounded-xl border p-4 transition-colors duration-200',
+        'bg-background-elevated/40 hover:bg-background-elevated/60',
+        'border-border-subtle hover:border-border-default',
+        'focus-within:ring-1 focus-within:ring-brand-base/40'
+      )}
+    >
+      <div className="flex items-start gap-3">
+        {/* Severity dot */}
+        <div className={cn('size-2.5 rounded-full mt-1.5 flex-shrink-0', severity.dot, severity.glow)} />
+
+        {/* Icon */}
+        <div className={cn(
+          'p-1.5 rounded-lg flex-shrink-0',
+          isPositive ? 'bg-success-base/10 text-success-base' : `${severity.bg} ${severity.text}`
+        )}>
+          <TypeIcon size={16} aria-hidden="true" />
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-sm font-semibold text-text-primary truncate">
+              {alert.studentName || 'Alumno'}
+            </span>
+            <span className={cn(
+              'text-[10px] font-medium px-1.5 py-0.5 rounded-md flex-shrink-0',
+              isPositive ? 'bg-success-base/10 text-success-base' : `${severity.bg} ${severity.text}`
+            )}>
+              {typeLabel}
+            </span>
+          </div>
+          <p className="text-xs text-text-muted leading-relaxed line-clamp-2">
+            {alert.description || alert.message || typeLabel}
+          </p>
+          <div className="flex items-center justify-between mt-2">
+            <span className="text-[10px] text-text-disabled">
+              {formatRelativeDate(alert.createdAt || alert.detectedAt)}
+            </span>
+            {alert.studentId && (
+              <button
+                type="button"
+                onClick={() => navigate(`/students/${alert.studentId}`)}
+                className="text-[10px] font-medium text-brand-base hover:text-brand-light transition-colors"
+              >
+                Ver perfil
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+/**
+ * Hub completo de alertas inteligentes con filtros, contadores y agrupacion.
+ *
+ * @param {Object} props
+ * @param {Array} props.alerts - Array de alertas del API
+ * @param {boolean} props.loading - Estado de carga
+ */
+function AlertsHub({ alerts = [], loading = false }) {
+  const { shouldReduceMotion } = useReducedMotion();
+  const [severityFilter, setSeverityFilter] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('all');
+  const [groupBy, setGroupBy] = useState('none');
+
+  // Contadores por severidad
+  const severityCounts = useMemo(() => {
+    const counts = { critical: 0, warning: 0, info: 0 };
+    for (const alert of alerts) {
+      const sev = alert.severity || 'info';
+      if (counts[sev] !== undefined) {
+        counts[sev]++;
+      }
+    }
+    return counts;
+  }, [alerts]);
+
+  // Opciones de filtro
+  const severityOptions = useMemo(() => [
+    { value: 'all', label: 'Todas' },
+    { value: 'critical', label: `Criticas (${severityCounts.critical})` },
+    { value: 'warning', label: `Warning (${severityCounts.warning})` },
+    { value: 'info', label: `Info (${severityCounts.info})` },
+  ], [severityCounts]);
+
+  const typeOptions = useMemo(() => {
+    const opts = [{ value: 'all', label: 'Todos los tipos' }];
+    for (const [value, label] of Object.entries(ALERT_TYPE_LABELS)) {
+      opts.push({ value, label });
+    }
+    return opts;
+  }, []);
+
+  // Alertas filtradas
+  const filteredAlerts = useMemo(() => {
+    let result = alerts;
+    if (severityFilter !== 'all') {
+      result = result.filter(a => a.severity === severityFilter);
+    }
+    if (typeFilter !== 'all') {
+      result = result.filter(a => a.type === typeFilter);
+    }
+    return result;
+  }, [alerts, severityFilter, typeFilter]);
+
+  // Alertas agrupadas
+  const groupedAlerts = useMemo(() => {
+    if (groupBy === 'none') return null;
+
+    const groups = {};
+    for (const alert of filteredAlerts) {
+      const key = groupBy === 'student'
+        ? (alert.studentName || alert.studentId || 'Sin alumno')
+        : (ALERT_TYPE_LABELS[alert.type] || alert.type || 'Otro');
+      if (!groups[key]) {
+        groups[key] = [];
+      }
+      groups[key].push(alert);
+    }
+    return groups;
+  }, [filteredAlerts, groupBy]);
+
+  const handleGroupChange = useCallback((mode) => {
+    setGroupBy(prev => prev === mode ? 'none' : mode);
+  }, []);
+
+  // Skeleton loading
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-3 gap-3">
+          {[0, 1, 2].map(i => (
+            <SkeletonShimmer key={i} className="h-20 rounded-xl" />
+          ))}
+        </div>
+        <div className="space-y-3">
+          {[0, 1, 2, 3].map(i => (
+            <SkeletonShimmer key={i} className="h-24 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Severity counters */}
+      <div className="grid grid-cols-3 gap-3">
+        <SeverityCounter severity="critical" count={severityCounts.critical} />
+        <SeverityCounter severity="warning" count={severityCounts.warning} />
+        <SeverityCounter severity="info" count={severityCounts.info} />
+      </div>
+
+      {/* Filters row */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-1.5 text-text-muted">
+          <Filter size={14} aria-hidden="true" />
+          <span className="text-xs font-medium">Filtros:</span>
+        </div>
+        <SelectPremium
+          options={severityOptions}
+          value={severityFilter}
+          onChange={setSeverityFilter}
+          placeholder="Severidad"
+          className="w-44"
+        />
+        <SelectPremium
+          options={typeOptions}
+          value={typeFilter}
+          onChange={setTypeFilter}
+          placeholder="Tipo"
+          className="w-52"
+        />
+
+        {/* Grouping toggle */}
+        <div className="flex items-center gap-1 ml-auto">
+          <button
+            type="button"
+            onClick={() => handleGroupChange('student')}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors duration-200',
+              groupBy === 'student'
+                ? 'bg-brand-base/20 text-brand-base border border-brand-base/30'
+                : 'bg-background-elevated/50 text-text-muted border border-border-subtle hover:text-text-secondary'
+            )}
+          >
+            <User size={12} aria-hidden="true" />
+            Por alumno
+          </button>
+          <button
+            type="button"
+            onClick={() => handleGroupChange('type')}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors duration-200',
+              groupBy === 'type'
+                ? 'bg-brand-base/20 text-brand-base border border-brand-base/30'
+                : 'bg-background-elevated/50 text-text-muted border border-border-subtle hover:text-text-secondary'
+            )}
+          >
+            <Layers size={12} aria-hidden="true" />
+            Por tipo
+          </button>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {filteredAlerts.length === 0 && (
+        <GlassCard variant="default" className="text-center py-8">
+          <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-xl bg-success-base/10">
+            <CheckCircle2 size={24} className="text-success-base" aria-hidden="true" />
+          </div>
+          <p className="text-sm font-semibold text-success-base">Sin alertas activas</p>
+          <p className="text-xs text-text-muted mt-1">
+            Todos los alumnos estan dentro de los parametros esperados.
+          </p>
+        </GlassCard>
+      )}
+
+      {/* Grouped view */}
+      {filteredAlerts.length > 0 && groupedAlerts && (
+        <div className="space-y-4">
+          {Object.entries(groupedAlerts).map(([groupName, groupAlertsList]) => (
+            <GlassCard key={groupName} variant="subtle" padding="sm">
+              <h4 className="text-sm font-bold text-text-primary mb-3 flex items-center gap-2">
+                {groupBy === 'student' ? (
+                  <User size={14} className="text-brand-base" aria-hidden="true" />
+                ) : (
+                  <Layers size={14} className="text-brand-base" aria-hidden="true" />
+                )}
+                {groupName}
+                <span className="text-xs text-text-muted font-normal">
+                  ({groupAlertsList.length})
+                </span>
+              </h4>
+              <motion.div
+                variants={shouldReduceMotion ? {} : listContainerVariants(0.04)}
+                initial={shouldReduceMotion ? false : 'hidden'}
+                animate="visible"
+                className="space-y-2"
+              >
+                {groupAlertsList.map((alert, idx) => (
+                  <AlertCard
+                    key={alert._id || alert.id || idx}
+                    alert={alert}
+                    shouldReduceMotion={shouldReduceMotion}
+                  />
+                ))}
+              </motion.div>
+            </GlassCard>
+          ))}
+        </div>
+      )}
+
+      {/* Flat list */}
+      {filteredAlerts.length > 0 && !groupedAlerts && (
+        <motion.div
+          variants={shouldReduceMotion ? {} : listContainerVariants(0.04)}
+          initial={shouldReduceMotion ? false : 'hidden'}
+          animate="visible"
+          className="space-y-2"
+        >
+          {filteredAlerts.map((alert, idx) => (
+            <AlertCard
+              key={alert._id || alert.id || idx}
+              alert={alert}
+              shouldReduceMotion={shouldReduceMotion}
+            />
+          ))}
+        </motion.div>
+      )}
+    </div>
+  );
+}
+
+AlertsHub.propTypes = {
+  alerts: PropTypes.array,
+  loading: PropTypes.bool,
+};
+
+export default memo(AlertsHub);

--- a/frontend/src/components/analytics/ContentEffectivenessMatrix.jsx
+++ b/frontend/src/components/analytics/ContentEffectivenessMatrix.jsx
@@ -1,0 +1,309 @@
+import { memo, useMemo, useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronDown, ChevronUp, Gamepad2, TrendingUp, BarChart3 } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn, DURATION, EASING } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Determina el color RAG segun la puntuacion.
+ * @param {number} score
+ * @returns {'green'|'amber'|'red'|'gray'}
+ */
+function getRAGColor(score) {
+  if (score == null || isNaN(score)) return 'gray';
+  if (score >= 70) return 'green';
+  if (score >= 50) return 'amber';
+  return 'red';
+}
+
+/**
+ * Estilos de fondo y texto segun color RAG.
+ */
+const RAG_CELL_STYLES = {
+  green: {
+    bg: 'bg-success-base/20 hover:bg-success-base/30',
+    text: 'text-success-base',
+    border: 'border-success-base/30',
+  },
+  amber: {
+    bg: 'bg-warning-base/20 hover:bg-warning-base/30',
+    text: 'text-warning-base',
+    border: 'border-warning-base/30',
+  },
+  red: {
+    bg: 'bg-error-base/20 hover:bg-error-base/30',
+    text: 'text-error-base',
+    border: 'border-error-base/30',
+  },
+  gray: {
+    bg: 'bg-background-surface/30',
+    text: 'text-text-muted',
+    border: 'border-border-subtle',
+  },
+};
+
+/**
+ * Celda individual de la matriz con puntuacion y color RAG.
+ */
+function MatrixCell({ score, gamesPlayed, improvement, isExpanded, onClick, shouldReduceMotion }) {
+  const ragColor = getRAGColor(score);
+  const styles = RAG_CELL_STYLES[ragColor];
+  const hasData = score != null && !isNaN(score);
+
+  return (
+    <td className="p-1">
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'w-full rounded-lg px-3 py-2.5 text-center transition-all duration-200',
+          'border focus-ring cursor-pointer',
+          styles.bg,
+          styles.border,
+          isExpanded && 'ring-2 ring-brand-base/30'
+        )}
+        aria-label={hasData ? `Puntuacion ${Math.round(score)}%, ${gamesPlayed || 0} partidas` : 'Sin datos'}
+      >
+        {hasData ? (
+          <span className={cn('text-sm font-bold tabular-nums', styles.text)}>
+            {Math.round(score)}%
+          </span>
+        ) : (
+          <span className="text-xs text-text-disabled">-</span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {isExpanded && hasData && (
+          <motion.div
+            initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+            transition={{ duration: DURATION.stateChange, ease: EASING.outQuart }}
+            className="mt-1 overflow-hidden"
+          >
+            <div className={cn(
+              'rounded-lg border p-2 text-xs space-y-1',
+              'bg-background-elevated/60 border-border-subtle'
+            )}>
+              <div className="flex items-center gap-1 text-text-muted">
+                <Gamepad2 size={10} aria-hidden="true" />
+                <span>{gamesPlayed || 0} partidas</span>
+              </div>
+              {improvement != null && (
+                <div className={cn(
+                  'flex items-center gap-1 font-medium',
+                  improvement >= 0 ? 'text-success-base' : 'text-error-base'
+                )}>
+                  <TrendingUp size={10} className={improvement < 0 ? 'rotate-180' : ''} aria-hidden="true" />
+                  <span>{improvement >= 0 ? '+' : ''}{Math.round(improvement)}%</span>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </td>
+  );
+}
+
+/**
+ * Matriz de efectividad de contenido que cruza mecanicas (filas) con contextos (columnas).
+ * Muestra puntuacion media con colores RAG en cada celda.
+ *
+ * @param {Object} props
+ * @param {Array} props.data - Datos del API getContentEffectiveness
+ * @param {Function} [props.onCellClick] - Callback al hacer clic en una celda
+ */
+function ContentEffectivenessMatrix({ data, onCellClick }) {
+  const { shouldReduceMotion } = useReducedMotion();
+  const [expandedCell, setExpandedCell] = useState(null);
+
+  // Construir la matriz cruzando mecanicas y contextos
+  const { mechanics, contexts, matrix } = useMemo(() => {
+    if (!data || !Array.isArray(data) || data.length === 0) {
+      return { mechanics: [], contexts: [], matrix: {} };
+    }
+
+    const mechanicSet = new Map();
+    const contextSet = new Map();
+    const cellMap = {};
+
+    for (const item of data) {
+      const mechName = item.mechanicName || item.mechanic || item.name;
+      const ctxName = item.contextName || item.context;
+      const mechId = item.mechanicId || mechName;
+      const ctxId = item.contextId || ctxName;
+
+      if (mechName && ctxName) {
+        // Datos cruzados (tienen ambos)
+        if (!mechanicSet.has(mechId)) {
+          mechanicSet.set(mechId, mechName);
+        }
+        if (!contextSet.has(ctxId)) {
+          contextSet.set(ctxId, ctxName);
+        }
+        const key = `${mechId}__${ctxId}`;
+        cellMap[key] = {
+          score: item.averageScore ?? item.score ?? null,
+          gamesPlayed: item.gamesPlayed ?? item.totalGames ?? 0,
+          improvement: item.improvement ?? item.trend ?? null,
+        };
+      } else if (mechName && !ctxName) {
+        // Solo mecanica
+        if (!mechanicSet.has(mechId)) {
+          mechanicSet.set(mechId, mechName);
+        }
+      } else if (ctxName && !mechName) {
+        // Solo contexto
+        if (!contextSet.has(ctxId)) {
+          contextSet.set(ctxId, ctxName);
+        }
+      }
+    }
+
+    // Si no hay suficientes datos cruzados, intentar construir un resumen
+    if (mechanicSet.size === 0 || contextSet.size === 0) {
+      // Construir desde datos planos agrupando por nombre
+      for (const item of data) {
+        const name = item.name || item.mechanicName || item.contextName || 'Desconocido';
+        const id = item._id || item.id || name;
+        const groupBy = item.groupBy || (item.mechanicName ? 'mechanic' : 'context');
+
+        if (groupBy === 'mechanic') {
+          if (!mechanicSet.has(id)) {
+            mechanicSet.set(id, name);
+          }
+        } else {
+          if (!contextSet.has(id)) {
+            contextSet.set(id, name);
+          }
+        }
+      }
+    }
+
+    return {
+      mechanics: Array.from(mechanicSet.entries()).map(([id, name]) => ({ id, name })),
+      contexts: Array.from(contextSet.entries()).map(([id, name]) => ({ id, name })),
+      matrix: cellMap,
+    };
+  }, [data]);
+
+  const handleCellClick = useCallback((mechId, ctxId) => {
+    const key = `${mechId}__${ctxId}`;
+    setExpandedCell(prev => prev === key ? null : key);
+    onCellClick?.({ mechanicId: mechId, contextId: ctxId });
+  }, [onCellClick]);
+
+  const canBuildMatrix = mechanics.length > 0 && contexts.length > 0;
+
+  if (!canBuildMatrix) {
+    return (
+      <GlassCard variant="default">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-2 rounded-lg bg-brand-base/10">
+            <BarChart3 size={20} className="text-brand-base" aria-hidden="true" />
+          </div>
+          <h3 className="text-base font-bold text-text-primary font-display">
+            Matriz de Efectividad
+          </h3>
+        </div>
+        <div className="h-40 flex items-center justify-center">
+          <p className="text-sm text-text-muted text-center">
+            No hay suficientes datos cruzados de contextos y mecanicas para generar la matriz.
+            <br />
+            Se necesitan partidas con distintas combinaciones.
+          </p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-brand-base/10">
+            <BarChart3 size={20} className="text-brand-base" aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="text-base font-bold text-text-primary font-display">
+              Matriz de Efectividad
+            </h3>
+            <p className="text-xs text-text-muted mt-0.5">
+              Mecanica x Contexto - Clic en celda para detalles
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-text-muted">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded bg-success-base/30" />
+            {'>'}70%
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded bg-warning-base/30" />
+            50-69%
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded bg-error-base/30" />
+            {'<'}50%
+          </span>
+        </div>
+      </div>
+
+      {/* Scrollable table */}
+      <div className="overflow-x-auto custom-scrollbar -mx-1">
+        <table className="w-full border-collapse min-w-[400px]">
+          <thead>
+            <tr>
+              <th className="text-left text-xs font-medium text-text-muted p-2 sticky left-0 bg-background-elevated/80 backdrop-blur-sm z-10 min-w-[120px]">
+                Mecanica / Contexto
+              </th>
+              {contexts.map(ctx => (
+                <th
+                  key={ctx.id}
+                  className="text-center text-xs font-medium text-text-muted p-2 min-w-[100px]"
+                >
+                  {ctx.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {mechanics.map(mech => (
+              <tr key={mech.id} className="border-t border-border-subtle/50">
+                <td className="text-sm font-medium text-text-secondary p-2 sticky left-0 bg-background-elevated/80 backdrop-blur-sm z-10">
+                  {mech.name}
+                </td>
+                {contexts.map(ctx => {
+                  const key = `${mech.id}__${ctx.id}`;
+                  const cellData = matrix[key] || {};
+                  return (
+                    <MatrixCell
+                      key={key}
+                      score={cellData.score}
+                      gamesPlayed={cellData.gamesPlayed}
+                      improvement={cellData.improvement}
+                      isExpanded={expandedCell === key}
+                      onClick={() => handleCellClick(mech.id, ctx.id)}
+                      shouldReduceMotion={shouldReduceMotion}
+                    />
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </GlassCard>
+  );
+}
+
+ContentEffectivenessMatrix.propTypes = {
+  data: PropTypes.array,
+  onCellClick: PropTypes.func,
+};
+
+export default memo(ContentEffectivenessMatrix);

--- a/frontend/src/components/analytics/ContentEffectivenessMatrix.jsx
+++ b/frontend/src/components/analytics/ContentEffectivenessMatrix.jsx
@@ -5,18 +5,7 @@ import PropTypes from 'prop-types';
 import { cn, DURATION, EASING } from '../../lib/utils';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 import GlassCard from '../ui/GlassCard';
-
-/**
- * Determina el color RAG segun la puntuacion.
- * @param {number} score
- * @returns {'green'|'amber'|'red'|'gray'}
- */
-function getRAGColor(score) {
-  if (score == null || isNaN(score)) return 'gray';
-  if (score >= 70) return 'green';
-  if (score >= 50) return 'amber';
-  return 'red';
-}
+import { scoreToRAGWithNull as getRAGColor } from '../../constants/analyticsThresholds';
 
 /**
  * Estilos de fondo y texto segun color RAG.

--- a/frontend/src/components/analytics/EngagementRadar.jsx
+++ b/frontend/src/components/analytics/EngagementRadar.jsx
@@ -67,12 +67,17 @@ function EngagementRadar({ engagement }) {
   const score = engagement?.engagementScore;
   const rag = score != null ? getEngagementRAG(score) : null;
 
-  if (chartData.length === 0) {
+  // Estado vacio: sin datos de componentes, o engagement nulo/cero
+  const isEmpty = chartData.length === 0 || !engagement || (!score && score !== undefined);
+
+  if (isEmpty) {
     return (
       <GlassCard variant="default" padding="none" className="p-5">
         <h3 className="text-base font-bold text-text-primary font-display mb-4">Engagement</h3>
-        <div className="py-8 text-center">
-          <p className="text-sm text-text-muted">Se necesitan mas datos para calcular el engagement.</p>
+        <div className="py-8 text-center px-6">
+          <p className="text-text-muted text-sm text-center">
+            Sin datos de engagement aun. Se calculara cuando el alumno acumule mas partidas.
+          </p>
         </div>
       </GlassCard>
     );

--- a/frontend/src/components/analytics/EngagementRadar.jsx
+++ b/frontend/src/components/analytics/EngagementRadar.jsx
@@ -1,0 +1,137 @@
+import { memo, useMemo } from 'react';
+import { RadarChart, Radar, PolarGrid, PolarAngleAxis, PolarRadiusAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Labels en espanol para los componentes de engagement
+ */
+const ENGAGEMENT_LABELS = {
+  playFrequency: 'Frecuencia',
+  regularity: 'Regularidad',
+  completionRate: 'Completado',
+  timeBetweenSessions: 'Constancia',
+  voluntaryReplays: 'Replays',
+};
+
+/**
+ * Color RAG del score total de engagement
+ */
+const getEngagementRAG = (score) => {
+  if (score >= 60) return { label: 'Alto', color: 'text-success-base', bg: 'bg-success-base/10' };
+  if (score >= 35) return { label: 'Medio', color: 'text-warning-base', bg: 'bg-warning-base/10' };
+  return { label: 'Bajo', color: 'text-error-base', bg: 'bg-error-base/10' };
+};
+
+/**
+ * Tooltip personalizado
+ */
+function CustomTooltip({ active, payload }) {
+  if (!active || !payload?.[0]) return null;
+  const data = payload[0].payload;
+  return (
+    <div className="bg-background-elevated border border-border-default rounded-lg p-2.5 shadow-xl text-sm">
+      <p className="text-text-primary font-medium">{data.label}</p>
+      <p className="text-text-muted tabular-nums">{Math.round(data.value)}%</p>
+    </div>
+  );
+}
+
+/**
+ * RadarChart de engagement con 5 ejes que muestra el desglose del
+ * score de engagement del estudiante. Visualiza que tan activo y
+ * consistente es el alumno en sus partidas.
+ *
+ * Los 5 componentes (pesos del backend analyticsHelpers.js):
+ * - playFrequency (0.25): cuantas partidas juega
+ * - regularity (0.25): que tan regular es
+ * - completionRate (0.30): que porcentaje completa
+ * - timeBetweenSessions (0.10): tiempo entre sesiones
+ * - voluntaryReplays (0.10): replays voluntarios
+ *
+ * @param {Object} props
+ * @param {Object} [props.engagement] - Datos del endpoint /student/:id/engagement
+ */
+function EngagementRadar({ engagement }) {
+  const chartData = useMemo(() => {
+    if (!engagement?.components) return [];
+
+    return Object.entries(ENGAGEMENT_LABELS).map(([key, label]) => ({
+      label,
+      value: (engagement.components[key] ?? 0) * 100,
+      fullMark: 100,
+    }));
+  }, [engagement]);
+
+  const score = engagement?.engagementScore;
+  const rag = score != null ? getEngagementRAG(score) : null;
+
+  if (chartData.length === 0) {
+    return (
+      <GlassCard variant="default" padding="none" className="p-5">
+        <h3 className="text-base font-bold text-text-primary font-display mb-4">Engagement</h3>
+        <div className="py-8 text-center">
+          <p className="text-sm text-text-muted">Se necesitan mas datos para calcular el engagement.</p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-base font-bold text-text-primary font-display">Engagement</h3>
+        {rag && (
+          <div className={cn("flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold", rag.bg, rag.color)}>
+            {Math.round(score)} — {rag.label}
+          </div>
+        )}
+      </div>
+
+      <div className="h-[220px] w-full">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+          <RadarChart cx="50%" cy="50%" outerRadius="70%" data={chartData}>
+            <PolarGrid
+              stroke="var(--color-border-subtle)"
+              gridType="polygon"
+            />
+            <PolarAngleAxis
+              dataKey="label"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+            />
+            <PolarRadiusAxis
+              domain={[0, 100]}
+              tick={false}
+              axisLine={false}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Radar
+              name="Engagement"
+              dataKey="value"
+              stroke="var(--color-accent-cyan)"
+              fill="var(--color-accent-cyan)"
+              fillOpacity={0.2}
+              strokeWidth={2}
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    </GlassCard>
+  );
+}
+
+EngagementRadar.propTypes = {
+  engagement: PropTypes.shape({
+    engagementScore: PropTypes.number,
+    components: PropTypes.shape({
+      playFrequency: PropTypes.number,
+      regularity: PropTypes.number,
+      completionRate: PropTypes.number,
+      timeBetweenSessions: PropTypes.number,
+      voluntaryReplays: PropTypes.number,
+    }),
+  }),
+};
+
+export default memo(EngagementRadar);

--- a/frontend/src/components/analytics/GameHistoryTable.jsx
+++ b/frontend/src/components/analytics/GameHistoryTable.jsx
@@ -1,0 +1,166 @@
+import { memo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Clock, ChevronDown, ChevronUp } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn, formatDate } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Badge de tier RAG para cada partida
+ */
+const TIER_BADGE = {
+  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base' },
+  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80' },
+  average: { label: 'Medio', className: 'bg-warning-base/15 text-warning-base' },
+  risk: { label: 'Bajo', className: 'bg-error-base/15 text-error-base' },
+};
+
+/**
+ * Obtiene el tier de una partida segun su score
+ */
+const getGameTier = (score) => {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  return 'risk';
+};
+
+/**
+ * Formatea milisegundos a formato legible (ej: "2m 30s")
+ */
+const formatDuration = (ms) => {
+  if (!ms || ms <= 0) return '—';
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+};
+
+/**
+ * Tabla de historial de partidas de un estudiante.
+ * Muestra las ultimas partidas con score, accuracy, duracion, y badge RAG.
+ * Soporta paginacion simple con "Ver mas".
+ *
+ * @param {Object} props
+ * @param {Array} props.games - Partidas del endpoint /student/:id/summary (lastGames)
+ * @param {number} [props.initialCount=10] - Numero de partidas visibles inicialmente
+ */
+function GameHistoryTable({ games, initialCount = 10 }) {
+  const { shouldReduceMotion } = useReducedMotion();
+  const [showAll, setShowAll] = useState(false);
+
+  if (!Array.isArray(games) || games.length === 0) {
+    return (
+      <GlassCard variant="default" padding="none" className="p-5">
+        <h3 className="text-base font-bold text-text-primary font-display mb-4">Historial de Partidas</h3>
+        <div className="py-6 text-center">
+          <Clock size={24} className="text-text-muted mx-auto mb-2" aria-hidden="true" />
+          <p className="text-sm text-text-muted">Este alumno aun no tiene partidas registradas.</p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  const visibleGames = showAll ? games : games.slice(0, initialCount);
+  const hasMore = games.length > initialCount;
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-bold text-text-primary font-display">Historial de Partidas</h3>
+        <span className="text-xs text-text-muted bg-background-surface/50 px-2 py-1 rounded-lg">
+          {games.length} partidas
+        </span>
+      </div>
+
+      <div className="overflow-x-auto -mx-5 px-5">
+        <table className="w-full text-sm" aria-label="Historial de partidas del estudiante">
+          <thead>
+            <tr className="border-b border-border-subtle">
+              <th className="text-left text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 pr-3">Fecha</th>
+              <th className="text-left text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 pr-3">Contexto</th>
+              <th className="text-left text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 pr-3">Mecanica</th>
+              <th className="text-right text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 pr-3">Score</th>
+              <th className="text-right text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 pr-3">Aciertos</th>
+              <th className="text-right text-xs font-semibold text-text-muted uppercase tracking-wider pb-3 hidden sm:table-cell">Duracion</th>
+            </tr>
+          </thead>
+          <tbody>
+            <AnimatePresence>
+              {visibleGames.map((game, index) => {
+                const tier = getGameTier(game.score ?? 0);
+                const badge = TIER_BADGE[tier];
+                const accuracy = game.correctAttempts != null && game.totalAttempts > 0
+                  ? Math.round((game.correctAttempts / game.totalAttempts) * 100)
+                  : null;
+
+                return (
+                  <motion.tr
+                    key={game.gameplayId || game._id || index}
+                    initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: shouldReduceMotion ? 0 : Math.min(index * 0.03, 0.3) }}
+                    className="border-b border-border-subtle/50 hover:bg-background-surface/30 transition-colors"
+                  >
+                    <td className="py-2.5 pr-3 text-text-secondary whitespace-nowrap">
+                      {game.completedAt ? formatDate(new Date(game.completedAt), 'short') : '—'}
+                    </td>
+                    <td className="py-2.5 pr-3 text-text-primary font-medium truncate max-w-[120px]">
+                      {game.contextName || '—'}
+                    </td>
+                    <td className="py-2.5 pr-3 text-text-secondary truncate max-w-[100px]">
+                      {game.mechanicName || '—'}
+                    </td>
+                    <td className="py-2.5 pr-3 text-right">
+                      <span className={cn("text-xs font-semibold px-1.5 py-0.5 rounded-md inline-block", badge.className)} aria-label={`Puntuacion ${Math.round(game.score ?? 0)}, nivel ${badge.label}`}>
+                        {Math.round(game.score ?? 0)}
+                      </span>
+                    </td>
+                    <td className="py-2.5 pr-3 text-right text-text-secondary tabular-nums">
+                      {accuracy != null ? `${accuracy}%` : '—'}
+                    </td>
+                    <td className="py-2.5 text-right text-text-muted tabular-nums hidden sm:table-cell">
+                      {formatDuration(game.completionTime)}
+                    </td>
+                  </motion.tr>
+                );
+              })}
+            </AnimatePresence>
+          </tbody>
+        </table>
+      </div>
+
+      {hasMore && (
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="w-full mt-4 py-2.5 text-sm font-medium text-text-muted hover:text-text-primary flex items-center justify-center gap-1.5 transition-colors"
+        >
+          {showAll ? (
+            <>Mostrar menos <ChevronUp size={14} /></>
+          ) : (
+            <>Ver todas ({games.length}) <ChevronDown size={14} /></>
+          )}
+        </button>
+      )}
+    </GlassCard>
+  );
+}
+
+GameHistoryTable.propTypes = {
+  games: PropTypes.arrayOf(PropTypes.shape({
+    gameplayId: PropTypes.string,
+    _id: PropTypes.string,
+    score: PropTypes.number,
+    correctAttempts: PropTypes.number,
+    totalAttempts: PropTypes.number,
+    completedAt: PropTypes.string,
+    completionTime: PropTypes.number,
+    contextName: PropTypes.string,
+    mechanicName: PropTypes.string,
+  })),
+  initialCount: PropTypes.number,
+};
+
+export default memo(GameHistoryTable);

--- a/frontend/src/components/analytics/GameHistoryTable.jsx
+++ b/frontend/src/components/analytics/GameHistoryTable.jsx
@@ -5,26 +5,7 @@ import PropTypes from 'prop-types';
 import { cn, formatDate } from '../../lib/utils';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 import GlassCard from '../ui/GlassCard';
-
-/**
- * Badge de tier RAG para cada partida
- */
-const TIER_BADGE = {
-  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base' },
-  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80' },
-  average: { label: 'Medio', className: 'bg-warning-base/15 text-warning-base' },
-  risk: { label: 'Bajo', className: 'bg-error-base/15 text-error-base' },
-};
-
-/**
- * Obtiene el tier de una partida segun su score
- */
-const getGameTier = (score) => {
-  if (score >= 90) return 'excellent';
-  if (score >= 70) return 'good';
-  if (score >= 50) return 'average';
-  return 'risk';
-};
+import { TIER_BADGE, scoreToTier as getGameTier } from '../../constants/analyticsThresholds';
 
 /**
  * Formatea milisegundos a formato legible (ej: "2m 30s")

--- a/frontend/src/components/analytics/NarrativeCard.jsx
+++ b/frontend/src/components/analytics/NarrativeCard.jsx
@@ -1,0 +1,109 @@
+import { memo } from 'react';
+import { motion } from 'framer-motion';
+import { CheckCircle2, Lightbulb, Target, MessageSquare } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Configuracion visual de cada seccion de la narrativa BI
+ */
+const SECTIONS = [
+  {
+    key: 'whatHappened',
+    label: 'Que paso',
+    icon: CheckCircle2,
+    color: 'text-success-base',
+    bg: 'bg-success-base/10',
+  },
+  {
+    key: 'soWhat',
+    label: 'Por que importa',
+    icon: Lightbulb,
+    color: 'text-warning-base',
+    bg: 'bg-warning-base/10',
+  },
+  {
+    key: 'nowWhat',
+    label: 'Que hacer',
+    icon: Target,
+    color: 'text-brand-light',
+    bg: 'bg-brand-base/10',
+  },
+];
+
+/**
+ * Card de narrativa BI siguiendo el framework "What Happened / So What / Now What".
+ * Traduce datos numericos en insights accionables para profesores.
+ *
+ * Las interpretaciones se generan server-side en analyticsHelpers.js
+ * y se entregan via los endpoints de trajectory/summary con enrichMetric().
+ *
+ * @param {Object} props
+ * @param {Object} [props.interpretation] - { whatHappened, soWhat, nowWhat } del backend
+ * @param {string} [props.title] - Titulo personalizado
+ */
+function NarrativeCard({ interpretation, title = 'Resumen del Alumno' }) {
+  const { shouldReduceMotion } = useReducedMotion();
+
+  const hasData = interpretation &&
+    (interpretation.whatHappened || interpretation.soWhat || interpretation.nowWhat);
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <MessageSquare size={18} className="text-brand-light" aria-hidden="true" />
+        <h3 className="text-base font-bold text-text-primary font-display">{title}</h3>
+      </div>
+
+      {hasData ? (
+        <div className="space-y-3">
+          {SECTIONS.map((section, index) => {
+            const text = interpretation[section.key];
+            if (!text) return null;
+            const Icon = section.icon;
+
+            return (
+              <motion.div
+                key={section.key}
+                initial={shouldReduceMotion ? false : { opacity: 0, x: -10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: shouldReduceMotion ? 0 : index * 0.1, duration: 0.3 }}
+                className="flex items-start gap-3"
+              >
+                <div className={cn("p-1.5 rounded-lg flex-shrink-0 mt-0.5", section.bg)}>
+                  <Icon size={14} className={section.color} aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-text-muted mb-0.5">
+                    {section.label}
+                  </p>
+                  <p className="text-sm text-text-secondary leading-relaxed">
+                    {text}
+                  </p>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="py-4 text-center">
+          <p className="text-sm text-text-muted">Se necesitan mas partidas para generar insights.</p>
+          <p className="text-xs text-text-disabled mt-1">Los insights se generan automaticamente con suficientes datos.</p>
+        </div>
+      )}
+    </GlassCard>
+  );
+}
+
+NarrativeCard.propTypes = {
+  interpretation: PropTypes.shape({
+    whatHappened: PropTypes.string,
+    soWhat: PropTypes.string,
+    nowWhat: PropTypes.string,
+  }),
+  title: PropTypes.string,
+};
+
+export default memo(NarrativeCard);

--- a/frontend/src/components/analytics/PerformanceByDimension.jsx
+++ b/frontend/src/components/analytics/PerformanceByDimension.jsx
@@ -1,0 +1,130 @@
+import { memo, useMemo } from 'react';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import PropTypes from 'prop-types';
+import ChartSection from '../dashboard/ChartSection';
+
+/**
+ * Color RAG segun score
+ */
+const getRAGColor = (score) => {
+  if (score >= 90) return 'var(--color-success-base)';
+  if (score >= 70) return 'var(--color-success-base)';
+  if (score >= 50) return 'var(--color-warning-base)';
+  return 'var(--color-error-base)';
+};
+
+/**
+ * Tooltip personalizado para el chart
+ */
+function CustomTooltip({ active, payload }) {
+  if (!active || !payload?.[0]) return null;
+  const data = payload[0].payload;
+
+  return (
+    <div className="bg-background-elevated border border-border-default rounded-lg p-3 shadow-xl text-sm">
+      <p className="font-semibold text-text-primary mb-1">{data.name}</p>
+      <p className="text-text-secondary">
+        Score: <span className="font-bold tabular-nums">{Math.round(data.score)}%</span>
+      </p>
+      {data.gamesPlayed != null && (
+        <p className="text-text-muted text-xs mt-0.5">{data.gamesPlayed} partidas</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * BarChart horizontal reutilizable que muestra rendimiento por dimension
+ * (contexto tematico O mecanica de juego). Barras coloreadas con RAG.
+ *
+ * @param {Object} props
+ * @param {string} props.title - Titulo de la seccion
+ * @param {Array} props.data - [{name, score, gamesPlayed}]
+ * @param {string} [props.dimension] - 'context' | 'mechanic' (para aria labels)
+ */
+function PerformanceByDimension({ title, data, dimension = 'context' }) {
+  const chartData = useMemo(() => {
+    if (!Array.isArray(data) || data.length === 0) return [];
+    return data
+      .map(item => ({
+        name: item.name || item.contextName || item.mechanicName || 'Sin nombre',
+        score: item.averageScore ?? item.score ?? 0,
+        gamesPlayed: item.gamesPlayed ?? item.totalGames ?? null,
+      }))
+      .sort((a, b) => b.score - a.score);
+  }, [data]);
+
+  if (chartData.length === 0) {
+    return (
+      <ChartSection title={title}>
+        <div className="py-8 text-center">
+          <p className="text-sm text-text-muted">Sin datos disponibles para esta dimension.</p>
+        </div>
+      </ChartSection>
+    );
+  }
+
+  const chartHeight = Math.max(160, chartData.length * 44 + 20);
+
+  return (
+    <ChartSection title={title}>
+      <div style={{ height: chartHeight }} className="w-full mt-2">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 0, right: 20, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              horizontal={false}
+              stroke="var(--color-border-subtle)"
+              strokeDasharray="3 3"
+            />
+            <XAxis
+              type="number"
+              domain={[0, 100]}
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              width={120}
+              tick={{ fill: 'var(--color-text-secondary)', fontSize: 12 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(255,255,255,0.03)' }} />
+            <Bar
+              dataKey="score"
+              radius={[0, 6, 6, 0]}
+              barSize={20}
+              aria-label={`Rendimiento por ${dimension === 'context' ? 'contexto' : 'mecanica'}`}
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={getRAGColor(entry.score)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </ChartSection>
+  );
+}
+
+PerformanceByDimension.propTypes = {
+  title: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string,
+    contextName: PropTypes.string,
+    mechanicName: PropTypes.string,
+    averageScore: PropTypes.number,
+    score: PropTypes.number,
+    gamesPlayed: PropTypes.number,
+    totalGames: PropTypes.number,
+  })),
+  dimension: PropTypes.oneOf(['context', 'mechanic']),
+};
+
+export default memo(PerformanceByDimension);

--- a/frontend/src/components/analytics/PerformanceByDimension.jsx
+++ b/frontend/src/components/analytics/PerformanceByDimension.jsx
@@ -2,16 +2,7 @@ import { memo, useMemo } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import PropTypes from 'prop-types';
 import ChartSection from '../dashboard/ChartSection';
-
-/**
- * Color RAG segun score
- */
-const getRAGColor = (score) => {
-  if (score >= 90) return 'var(--color-success-base)';
-  if (score >= 70) return 'var(--color-success-base)';
-  if (score >= 50) return 'var(--color-warning-base)';
-  return 'var(--color-error-base)';
-};
+import { getRAGCSSColor as getRAGColor } from '../../constants/analyticsThresholds';
 
 /**
  * Tooltip personalizado para el chart
@@ -26,8 +17,10 @@ function CustomTooltip({ active, payload }) {
       <p className="text-text-secondary">
         Score: <span className="font-bold tabular-nums">{Math.round(data.score)}%</span>
       </p>
-      {data.gamesPlayed != null && (
-        <p className="text-text-muted text-xs mt-0.5">{data.gamesPlayed} partidas</p>
+      {(data.gamesPlayed != null || data.totalGames != null) && (
+        <p className="text-text-muted text-xs mt-0.5">
+          {data.gamesPlayed ?? data.totalGames} {(data.gamesPlayed ?? data.totalGames) === 1 ? 'partida' : 'partidas'}
+        </p>
       )}
     </div>
   );

--- a/frontend/src/components/analytics/ReportGenerator.jsx
+++ b/frontend/src/components/analytics/ReportGenerator.jsx
@@ -1,0 +1,603 @@
+import { memo, useState, useCallback, useRef, useEffect, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  FileText,
+  Download,
+  Printer,
+  Users,
+  User,
+  BarChart3,
+  TrendingUp,
+  Award,
+  AlertTriangle,
+} from 'lucide-react';
+import { cn, DURATION, EASING, exportToCSV } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import analyticsService from '../../services/analytics';
+import { isAbortError } from '../../services/api';
+import { captureException } from '../../lib/sentry';
+import GlassCard from '../ui/GlassCard';
+import SelectPremium from '../ui/SelectPremium';
+import ButtonPremium from '../ui/ButtonPremium';
+import SkeletonShimmer from '../ui/SkeletonShimmer';
+import ErrorState from '../ui/ErrorState';
+
+/**
+ * Opciones de tipo de reporte.
+ */
+const REPORT_TYPE_OPTIONS = [
+  { value: 'classroom', label: 'Clase completa', icon: <Users size={16} /> },
+  { value: 'student', label: 'Estudiante individual', icon: <User size={16} /> },
+];
+
+/**
+ * Opciones de periodo.
+ */
+const PERIOD_OPTIONS = [
+  { value: '7d', label: 'Ultimos 7 dias' },
+  { value: '30d', label: 'Ultimos 30 dias' },
+  { value: '90d', label: 'Ultimos 90 dias' },
+];
+
+/**
+ * Opciones de formato.
+ */
+const FORMAT_OPTIONS = [
+  { value: 'summary', label: 'Resumen' },
+  { value: 'detailed', label: 'Detallado' },
+];
+
+/**
+ * Obtiene el color RAG segun la puntuacion.
+ */
+function getScoreRAGColor(score) {
+  if (score >= 70) return 'green';
+  if (score >= 50) return 'amber';
+  return 'red';
+}
+
+/**
+ * Componente de KPI simple para el reporte.
+ */
+function ReportKPI({ label, value, suffix, icon: Icon, ragColor }) {
+  const colorStyles = {
+    green: 'text-success-base bg-success-base/10',
+    amber: 'text-warning-base bg-warning-base/10',
+    red: 'text-error-base bg-error-base/10',
+    blue: 'text-info-base bg-info-base/10',
+    default: 'text-brand-base bg-brand-base/10',
+  };
+  const style = colorStyles[ragColor] || colorStyles.default;
+
+  return (
+    <div className="rounded-xl border border-border-subtle bg-background-elevated/30 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-text-muted uppercase tracking-wider">{label}</span>
+        {Icon && (
+          <div className={cn('p-1.5 rounded-lg', style)}>
+            <Icon size={14} aria-hidden="true" />
+          </div>
+        )}
+      </div>
+      <div className="flex items-baseline gap-1">
+        <span className="text-xl font-bold text-text-primary font-display tabular-nums">
+          {value ?? '-'}
+        </span>
+        {suffix && <span className="text-sm text-text-muted">{suffix}</span>}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Vista del reporte de clase.
+ */
+function ClassroomReportView({ data }) {
+  if (!data) return null;
+
+  const kpis = data.kpis || data.summary || {};
+  const distribution = data.distribution || [];
+  const topStudents = data.topStudents || data.top || [];
+  const bottomStudents = data.bottomStudents || data.bottom || [];
+
+  return (
+    <div className="space-y-5">
+      {/* KPIs */}
+      <div>
+        <h4 className="text-sm font-bold text-text-primary mb-3 flex items-center gap-2">
+          <BarChart3 size={14} className="text-brand-base" aria-hidden="true" />
+          Resumen General
+        </h4>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <ReportKPI
+            label="Puntuacion Media"
+            value={kpis.averageScore != null ? Math.round(kpis.averageScore) : kpis.avgScore}
+            suffix="%"
+            icon={Award}
+            ragColor={getScoreRAGColor(kpis.averageScore)}
+          />
+          <ReportKPI
+            label="Total Partidas"
+            value={kpis.totalGames ?? kpis.gamesPlayed ?? 0}
+            icon={BarChart3}
+            ragColor="blue"
+          />
+          <ReportKPI
+            label="Alumnos Activos"
+            value={kpis.activeStudents ?? kpis.totalStudents ?? 0}
+            icon={Users}
+            ragColor="default"
+          />
+          <ReportKPI
+            label="Tasa Completado"
+            value={kpis.completionRate != null ? Math.round(kpis.completionRate) : '-'}
+            suffix="%"
+            icon={TrendingUp}
+            ragColor="green"
+          />
+        </div>
+      </div>
+
+      {/* Distribution */}
+      {distribution.length > 0 && (
+        <div>
+          <h4 className="text-sm font-bold text-text-primary mb-3">Distribucion de Rendimiento</h4>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+            {distribution.map((tier) => (
+              <div
+                key={tier.range || tier.tier || tier.name}
+                className="rounded-lg border border-border-subtle bg-background-elevated/20 p-3 text-center"
+              >
+                <p className="text-lg font-bold text-text-primary tabular-nums">{tier.count ?? 0}</p>
+                <p className="text-xs text-text-muted">{tier.range || tier.tier || tier.name}</p>
+                {tier.percentage != null && (
+                  <p className="text-[10px] text-text-disabled mt-0.5">{Math.round(tier.percentage)}%</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Top / Bottom students */}
+      {(topStudents.length > 0 || bottomStudents.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {topStudents.length > 0 && (
+            <div>
+              <h4 className="text-sm font-bold text-success-base mb-2 flex items-center gap-1.5">
+                <TrendingUp size={14} aria-hidden="true" />
+                Mejores Alumnos
+              </h4>
+              <div className="space-y-1.5">
+                {topStudents.slice(0, 5).map((s, idx) => (
+                  <div
+                    key={s._id || s.studentId || idx}
+                    className="flex items-center justify-between px-3 py-2 rounded-lg bg-success-base/5 border border-success-base/10"
+                  >
+                    <span className="text-sm text-text-primary truncate">{s.name || s.studentName || `Alumno ${idx + 1}`}</span>
+                    <span className="text-sm font-bold text-success-base tabular-nums">
+                      {Math.round(s.averageScore ?? s.score ?? 0)}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {bottomStudents.length > 0 && (
+            <div>
+              <h4 className="text-sm font-bold text-error-base mb-2 flex items-center gap-1.5">
+                <AlertTriangle size={14} aria-hidden="true" />
+                Alumnos en Riesgo
+              </h4>
+              <div className="space-y-1.5">
+                {bottomStudents.slice(0, 5).map((s, idx) => (
+                  <div
+                    key={s._id || s.studentId || idx}
+                    className="flex items-center justify-between px-3 py-2 rounded-lg bg-error-base/5 border border-error-base/10"
+                  >
+                    <span className="text-sm text-text-primary truncate">{s.name || s.studentName || `Alumno ${idx + 1}`}</span>
+                    <span className="text-sm font-bold text-error-base tabular-nums">
+                      {Math.round(s.averageScore ?? s.score ?? 0)}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Vista del reporte individual.
+ */
+function StudentReportView({ data }) {
+  if (!data) return null;
+
+  const kpis = data.kpis || data.summary || {};
+  const performance = data.performance || data.performanceSummary || {};
+  const recommendations = data.recommendations || [];
+
+  return (
+    <div className="space-y-5">
+      {/* KPIs */}
+      <div>
+        <h4 className="text-sm font-bold text-text-primary mb-3 flex items-center gap-2">
+          <User size={14} className="text-brand-base" aria-hidden="true" />
+          Rendimiento Individual
+        </h4>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+          <ReportKPI
+            label="Puntuacion Media"
+            value={kpis.averageScore != null ? Math.round(kpis.averageScore) : '-'}
+            suffix="%"
+            icon={Award}
+            ragColor={getScoreRAGColor(kpis.averageScore)}
+          />
+          <ReportKPI
+            label="Partidas Jugadas"
+            value={kpis.totalGames ?? kpis.gamesPlayed ?? 0}
+            icon={BarChart3}
+            ragColor="blue"
+          />
+          <ReportKPI
+            label="Mejor Puntuacion"
+            value={kpis.bestScore != null ? Math.round(kpis.bestScore) : '-'}
+            suffix="%"
+            icon={Award}
+            ragColor="green"
+          />
+          <ReportKPI
+            label="Tasa de Acierto"
+            value={kpis.accuracy != null ? Math.round(kpis.accuracy) : '-'}
+            suffix="%"
+            icon={TrendingUp}
+          />
+        </div>
+      </div>
+
+      {/* Performance summary */}
+      {(performance.strengths || performance.weaknesses) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {performance.strengths?.length > 0 && (
+            <div className="rounded-xl border border-success-base/20 bg-success-base/5 p-4">
+              <h4 className="text-sm font-bold text-success-base mb-2">Fortalezas</h4>
+              <ul className="space-y-1">
+                {performance.strengths.map((item, idx) => (
+                  <li key={idx} className="text-xs text-text-secondary flex items-start gap-1.5">
+                    <TrendingUp size={12} className="text-success-base mt-0.5 flex-shrink-0" aria-hidden="true" />
+                    {typeof item === 'string' ? item : item.name || item.context || 'N/A'}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {performance.weaknesses?.length > 0 && (
+            <div className="rounded-xl border border-error-base/20 bg-error-base/5 p-4">
+              <h4 className="text-sm font-bold text-error-base mb-2">Areas de Mejora</h4>
+              <ul className="space-y-1">
+                {performance.weaknesses.map((item, idx) => (
+                  <li key={idx} className="text-xs text-text-secondary flex items-start gap-1.5">
+                    <AlertTriangle size={12} className="text-error-base mt-0.5 flex-shrink-0" aria-hidden="true" />
+                    {typeof item === 'string' ? item : item.name || item.context || 'N/A'}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Recommendations */}
+      {recommendations.length > 0 && (
+        <div>
+          <h4 className="text-sm font-bold text-text-primary mb-2">Recomendaciones</h4>
+          <ul className="space-y-2">
+            {recommendations.map((rec, idx) => (
+              <li
+                key={idx}
+                className="text-xs text-text-secondary bg-background-elevated/30 rounded-lg border border-border-subtle px-3 py-2"
+              >
+                {typeof rec === 'string' ? rec : rec.message || rec.description || 'N/A'}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Generador de informes con formulario, vista previa y exportacion.
+ * Obtiene sus propios datos de la API.
+ */
+function ReportGenerator() {
+  const { shouldReduceMotion } = useReducedMotion();
+  const [reportType, setReportType] = useState('classroom');
+  const [studentId, setStudentId] = useState('');
+  const [period, setPeriod] = useState('30d');
+  const [format, setFormat] = useState('summary');
+
+  const [students, setStudents] = useState([]);
+  const [studentsLoading, setStudentsLoading] = useState(false);
+
+  const [reportData, setReportData] = useState(null);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState(null);
+
+  const abortRef = useRef(null);
+  const studentsAbortRef = useRef(null);
+
+  // Fetch students list when report type changes to individual
+  useEffect(() => {
+    if (reportType !== 'student') return;
+
+    studentsAbortRef.current?.abort();
+    const controller = new AbortController();
+    studentsAbortRef.current = controller;
+
+    const fetchStudents = async () => {
+      try {
+        setStudentsLoading(true);
+        const data = await analyticsService.getClassroomStudents(
+          { sort: 'name', order: 'asc' },
+          { signal: controller.signal }
+        );
+        const list = data?.students || data || [];
+        setStudents(list);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        captureException(err);
+      } finally {
+        if (!controller.signal.aborted) {
+          setStudentsLoading(false);
+        }
+      }
+    };
+
+    fetchStudents();
+    return () => controller.abort();
+  }, [reportType]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      studentsAbortRef.current?.abort();
+    };
+  }, []);
+
+  // Student options for the selector
+  const studentOptions = useMemo(() => {
+    return students.map(s => ({
+      value: s._id || s.studentId || s.id,
+      label: s.name || s.studentName || `Alumno ${s._id?.slice(-4) || ''}`,
+    }));
+  }, [students]);
+
+  // Generate report
+  const handleGenerate = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      setGenerating(true);
+      setError(null);
+      setReportData(null);
+
+      const params = { timeRange: period, format };
+      let data;
+
+      if (reportType === 'student') {
+        if (!studentId) {
+          setError('Selecciona un estudiante para generar el informe.');
+          setGenerating(false);
+          return;
+        }
+        data = await analyticsService.getStudentReport(studentId, params, {
+          signal: controller.signal,
+        });
+      } else {
+        data = await analyticsService.getClassroomReport(params, {
+          signal: controller.signal,
+        });
+      }
+
+      setReportData(data);
+    } catch (err) {
+      if (isAbortError(err)) return;
+      captureException(err);
+      setError('Error al generar el informe. Intenta de nuevo.');
+    } finally {
+      if (!controller.signal.aborted) {
+        setGenerating(false);
+      }
+    }
+  }, [reportType, studentId, period, format]);
+
+  // Export CSV
+  const handleExportCSV = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const data = await analyticsService.getClassroomExport(
+        { timeRange: period },
+        { signal: controller.signal }
+      );
+
+      const rows = data?.rows || data?.students || data || [];
+      if (rows.length === 0) return;
+
+      const sampleKeys = Object.keys(rows[0]);
+      const columns = sampleKeys.map(key => ({ key, label: key }));
+      exportToCSV(rows, `informe-${reportType}-${period}`, columns);
+    } catch (err) {
+      if (isAbortError(err)) return;
+      captureException(err);
+    }
+  }, [period, reportType]);
+
+  // Print
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
+
+  const canGenerate = reportType === 'classroom' || (reportType === 'student' && studentId);
+
+  return (
+    <div className="space-y-6">
+      {/* Form controls */}
+      <GlassCard variant="default">
+        <div className="flex items-center gap-3 mb-5">
+          <div className="p-2 rounded-lg bg-brand-base/10">
+            <FileText size={20} className="text-brand-base" aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="text-base font-bold text-text-primary font-display">Generar Informe</h3>
+            <p className="text-xs text-text-muted mt-0.5">Configura los parametros del reporte</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <SelectPremium
+            label="Tipo de reporte"
+            options={REPORT_TYPE_OPTIONS}
+            value={reportType}
+            onChange={(val) => {
+              setReportType(val);
+              setStudentId('');
+              setReportData(null);
+            }}
+          />
+
+          {reportType === 'student' && (
+            <SelectPremium
+              label="Estudiante"
+              options={studentOptions}
+              value={studentId}
+              onChange={setStudentId}
+              placeholder={studentsLoading ? 'Cargando...' : 'Seleccionar alumno'}
+              disabled={studentsLoading}
+            />
+          )}
+
+          <SelectPremium
+            label="Periodo"
+            options={PERIOD_OPTIONS}
+            value={period}
+            onChange={setPeriod}
+          />
+
+          <SelectPremium
+            label="Formato"
+            options={FORMAT_OPTIONS}
+            value={format}
+            onChange={setFormat}
+          />
+        </div>
+
+        <div className="mt-5 flex items-center gap-3">
+          <ButtonPremium
+            variant="primary"
+            onClick={handleGenerate}
+            loading={generating}
+            disabled={!canGenerate}
+            icon={<FileText size={18} />}
+          >
+            Generar Informe
+          </ButtonPremium>
+
+          {reportData && (
+            <motion.div
+              initial={shouldReduceMotion ? false : { opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: DURATION.stateChange, ease: EASING.outQuart }}
+              className="flex items-center gap-2"
+            >
+              <ButtonPremium
+                variant="secondary"
+                size="sm"
+                onClick={handleExportCSV}
+                icon={<Download size={16} />}
+              >
+                Exportar CSV
+              </ButtonPremium>
+              <ButtonPremium
+                variant="ghost"
+                size="sm"
+                onClick={handlePrint}
+                icon={<Printer size={16} />}
+              >
+                Imprimir
+              </ButtonPremium>
+            </motion.div>
+          )}
+        </div>
+      </GlassCard>
+
+      {/* Error state */}
+      {error && (
+        <ErrorState
+          title="Error en el informe"
+          message={error}
+          onRetry={handleGenerate}
+        />
+      )}
+
+      {/* Loading state */}
+      {generating && (
+        <GlassCard variant="default">
+          <div className="space-y-4">
+            <SkeletonShimmer className="h-6 w-48" />
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              {[0, 1, 2, 3].map(i => (
+                <SkeletonShimmer key={i} className="h-20 rounded-xl" />
+              ))}
+            </div>
+            <SkeletonShimmer variant="text" lines={4} />
+          </div>
+        </GlassCard>
+      )}
+
+      {/* Report preview */}
+      <AnimatePresence mode="wait">
+        {reportData && !generating && (
+          <motion.div
+            key="report-preview"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+            transition={{ duration: DURATION.entrance, ease: EASING.outExpo }}
+          >
+            <GlassCard variant="solid">
+              <div className="flex items-center justify-between mb-5">
+                <h3 className="text-base font-bold text-text-primary font-display">
+                  Vista Previa del Informe
+                </h3>
+                <span className="text-xs text-text-muted px-2 py-1 rounded-lg bg-background-surface/50 border border-border-subtle">
+                  {reportType === 'classroom' ? 'Clase completa' : 'Individual'}
+                  {' \u2022 '}
+                  {PERIOD_OPTIONS.find(p => p.value === period)?.label || period}
+                </span>
+              </div>
+
+              {reportType === 'classroom' ? (
+                <ClassroomReportView data={reportData} />
+              ) : (
+                <StudentReportView data={reportData} />
+              )}
+            </GlassCard>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default memo(ReportGenerator);

--- a/frontend/src/components/analytics/ReportGenerator.jsx
+++ b/frontend/src/components/analytics/ReportGenerator.jsx
@@ -21,6 +21,7 @@ import SelectPremium from '../ui/SelectPremium';
 import ButtonPremium from '../ui/ButtonPremium';
 import SkeletonShimmer from '../ui/SkeletonShimmer';
 import ErrorState from '../ui/ErrorState';
+import { scoreToRAG as getScoreRAGColor } from '../../constants/analyticsThresholds';
 
 /**
  * Opciones de tipo de reporte.
@@ -46,15 +47,6 @@ const FORMAT_OPTIONS = [
   { value: 'summary', label: 'Resumen' },
   { value: 'detailed', label: 'Detallado' },
 ];
-
-/**
- * Obtiene el color RAG segun la puntuacion.
- */
-function getScoreRAGColor(score) {
-  if (score >= 70) return 'green';
-  if (score >= 50) return 'amber';
-  return 'red';
-}
 
 /**
  * Componente de KPI simple para el reporte.

--- a/frontend/src/components/analytics/StrengthsWeaknesses.jsx
+++ b/frontend/src/components/analytics/StrengthsWeaknesses.jsx
@@ -1,0 +1,134 @@
+import { memo, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { ThumbsUp, AlertTriangle } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Deriva fortalezas y debilidades de los datos de rendimiento por dimension.
+ * Fortalezas = top items con mejor accuracy. Debilidades = peores.
+ *
+ * @param {Array} performanceByContext - Rendimiento por contexto
+ * @param {Array} performanceByMechanic - Rendimiento por mecanica
+ * @param {number} count - Numero de items a mostrar por lado
+ * @returns {{ strengths: Array, weaknesses: Array }}
+ */
+const deriveStrengthsWeaknesses = (performanceByContext = [], performanceByMechanic = [], count = 3) => {
+  const allItems = [
+    ...performanceByContext.map(c => ({
+      name: c.name || c.contextName || 'Sin nombre',
+      score: c.averageScore ?? c.score ?? 0,
+      gamesPlayed: c.gamesPlayed ?? c.totalGames ?? 0,
+      type: 'context',
+    })),
+    ...performanceByMechanic.map(m => ({
+      name: m.name || m.mechanicName || 'Sin nombre',
+      score: m.averageScore ?? m.score ?? 0,
+      gamesPlayed: m.gamesPlayed ?? m.totalGames ?? 0,
+      type: 'mechanic',
+    })),
+  ].filter(item => item.gamesPlayed > 0);
+
+  const sorted = [...allItems].sort((a, b) => b.score - a.score);
+
+  return {
+    strengths: sorted.slice(0, count),
+    weaknesses: sorted.length > count ? sorted.slice(-count).reverse() : [],
+  };
+};
+
+/**
+ * Muestra las fortalezas y debilidades del estudiante como tarjetas coloreadas.
+ * Derivado automaticamente de los datos de rendimiento por contexto/mecanica.
+ *
+ * @param {Object} props
+ * @param {Array} props.performanceByContext - Rendimiento por contexto
+ * @param {Array} props.performanceByMechanic - Rendimiento por mecanica
+ */
+function StrengthsWeaknesses({ performanceByContext, performanceByMechanic }) {
+  const { shouldReduceMotion } = useReducedMotion();
+  const { strengths, weaknesses } = useMemo(
+    () => deriveStrengthsWeaknesses(performanceByContext, performanceByMechanic),
+    [performanceByContext, performanceByMechanic]
+  );
+
+  if (strengths.length === 0 && weaknesses.length === 0) {
+    return null;
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <h3 className="text-base font-bold text-text-primary font-display mb-4">Fortalezas y Debilidades</h3>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {/* Strengths */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <ThumbsUp size={14} className="text-success-base" aria-hidden="true" />
+            <span className="text-xs font-semibold text-success-base uppercase tracking-wider">Fortalezas</span>
+          </div>
+          <div className="space-y-2">
+            {strengths.map((item, index) => (
+              <motion.div
+                key={`strength-${item.name}`}
+                initial={shouldReduceMotion ? false : { opacity: 0, x: -10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: shouldReduceMotion ? 0 : index * 0.08 }}
+                className="p-3 rounded-lg bg-success-base/5 border border-success-base/10"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-text-primary truncate">{item.name}</span>
+                  <span className="text-sm font-bold text-success-base tabular-nums ml-2">{Math.round(item.score)}%</span>
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="text-[10px] text-text-muted capitalize">{item.type === 'context' ? 'Contexto' : 'Mecanica'}</span>
+                  <span className="text-[10px] text-text-disabled">{'\u2022'}</span>
+                  <span className="text-[10px] text-text-muted">{item.gamesPlayed} partidas</span>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+
+        {/* Weaknesses */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <AlertTriangle size={14} className="text-error-base" aria-hidden="true" />
+            <span className="text-xs font-semibold text-error-base uppercase tracking-wider">A mejorar</span>
+          </div>
+          <div className="space-y-2">
+            {weaknesses.length > 0 ? weaknesses.map((item, index) => (
+              <motion.div
+                key={`weakness-${item.name}`}
+                initial={shouldReduceMotion ? false : { opacity: 0, x: 10 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: shouldReduceMotion ? 0 : index * 0.08 }}
+                className="p-3 rounded-lg bg-error-base/5 border border-error-base/10"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-text-primary truncate">{item.name}</span>
+                  <span className="text-sm font-bold text-error-base tabular-nums ml-2">{Math.round(item.score)}%</span>
+                </div>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="text-[10px] text-text-muted capitalize">{item.type === 'context' ? 'Contexto' : 'Mecanica'}</span>
+                  <span className="text-[10px] text-text-disabled">{'\u2022'}</span>
+                  <span className="text-[10px] text-text-muted">{item.gamesPlayed} partidas</span>
+                </div>
+              </motion.div>
+            )) : (
+              <p className="text-xs text-text-muted py-4 text-center">Sin debilidades identificadas con los datos actuales.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+StrengthsWeaknesses.propTypes = {
+  performanceByContext: PropTypes.array,
+  performanceByMechanic: PropTypes.array,
+};
+
+export default memo(StrengthsWeaknesses);

--- a/frontend/src/components/analytics/StudentKPICard.jsx
+++ b/frontend/src/components/analytics/StudentKPICard.jsx
@@ -1,0 +1,157 @@
+import { memo } from 'react';
+import { motion } from 'framer-motion';
+import { ArrowUpRight, ArrowDownRight, Minus } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn } from '../../lib/utils';
+import { useReducedMotion } from '../../hooks/useReducedMotion';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Colores RAG segun estado
+ */
+const RAG_STYLES = {
+  green: {
+    border: 'border-l-success-base',
+    dot: 'bg-success-base',
+    glow: 'shadow-[0_0_8px_var(--color-success-glow)]',
+    text: 'text-success-base',
+  },
+  amber: {
+    border: 'border-l-warning-base',
+    dot: 'bg-warning-base',
+    glow: 'shadow-[0_0_8px_var(--color-warning-glow)]',
+    text: 'text-warning-base',
+  },
+  red: {
+    border: 'border-l-error-base',
+    dot: 'bg-error-base',
+    glow: 'shadow-[0_0_8px_var(--color-error-glow)]',
+    text: 'text-error-base',
+  },
+  gray: {
+    border: 'border-l-text-muted',
+    dot: 'bg-text-muted',
+    glow: '',
+    text: 'text-text-muted',
+  },
+};
+
+/**
+ * Animacion del numero (cuenta de 0 a valor final)
+ */
+function AnimatedValue({ value, suffix = '' }) {
+  const { shouldReduceMotion } = useReducedMotion();
+  const numericPart = typeof value === 'number' ? value : parseFloat(value);
+
+  if (shouldReduceMotion || isNaN(numericPart)) {
+    return <span>{value}{suffix}</span>;
+  }
+
+  return (
+    <motion.span
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.3 }}
+    >
+      {typeof value === 'number' ? Math.round(value) : value}{suffix}
+    </motion.span>
+  );
+}
+
+/**
+ * KPI Card con indicador RAG (semaforo), valor principal, comparativa con clase,
+ * y descripcion. Componente firma del sistema de analytics.
+ *
+ * El patron de 4 capas:
+ * 1. Valor numerico principal
+ * 2. Indicador RAG (borde izquierdo coloreado + dot)
+ * 3. Comparativa contextual (vs clase)
+ * 4. Micro-narrativa (label descriptivo)
+ *
+ * @param {Object} props
+ * @param {string} props.label - Nombre del KPI
+ * @param {string|number} props.value - Valor principal
+ * @param {string} [props.suffix] - Sufijo (%, s, pts)
+ * @param {string} [props.ragStatus] - Estado RAG: green | amber | red | gray
+ * @param {string} [props.comparison] - Texto de comparativa ("vs clase: +11%")
+ * @param {boolean} [props.comparisonPositive] - Si la comparativa es positiva
+ * @param {React.ReactNode} [props.icon] - Icono opcional
+ */
+function StudentKPICard({
+  label,
+  value,
+  suffix = '',
+  ragStatus = 'gray',
+  comparison,
+  comparisonPositive,
+  icon,
+}) {
+  const rag = RAG_STYLES[ragStatus] || RAG_STYLES.gray;
+
+  return (
+    <GlassCard
+      variant="default"
+      padding="none"
+      className={cn(
+        "p-4 border-l-4 transition-[box-shadow,border-color] duration-300",
+        "hover:shadow-[0_4px_16px_rgba(0,0,0,0.2)]",
+        rag.border
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-text-muted uppercase tracking-wider mb-1 truncate">
+            {label}
+          </p>
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-2xl font-bold text-text-primary font-display tabular-nums">
+              <AnimatedValue value={value} suffix={suffix} />
+            </span>
+            {suffix && <span className="text-sm text-text-muted font-medium">{suffix}</span>}
+          </div>
+        </div>
+
+        {/* RAG dot + optional icon */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {icon && (
+            <div className={cn("p-1.5 rounded-lg bg-background-surface/50", rag.text)}>
+              {icon}
+            </div>
+          )}
+          <div className={cn("size-2.5 rounded-full", rag.dot, ragStatus !== 'gray' && rag.glow)} aria-label={`Estado: ${ragStatus}`} />
+        </div>
+      </div>
+
+      {/* Comparison line */}
+      {comparison && (
+        <div className={cn(
+          "mt-2 flex items-center gap-1.5 px-2 py-1 rounded-md text-xs font-medium",
+          comparisonPositive === true && 'bg-success-base/8',
+          comparisonPositive === false && 'bg-error-base/8'
+        )}>
+          {comparisonPositive != null && (
+            comparisonPositive
+              ? <ArrowUpRight size={12} className="text-success-base" aria-hidden="true" />
+              : <ArrowDownRight size={12} className="text-error-base" aria-hidden="true" />
+          )}
+          {comparisonPositive == null && (
+            <Minus size={12} className="text-text-muted" aria-hidden="true" />
+          )}
+          <span className="text-xs text-text-muted font-medium">{comparison}</span>
+        </div>
+      )}
+    </GlassCard>
+  );
+}
+
+StudentKPICard.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  suffix: PropTypes.string,
+  ragStatus: PropTypes.oneOf(['green', 'amber', 'red', 'gray']),
+  comparison: PropTypes.string,
+  comparisonPositive: PropTypes.bool,
+  icon: PropTypes.node,
+};
+
+export default memo(StudentKPICard);

--- a/frontend/src/components/analytics/TrajectoryChart.jsx
+++ b/frontend/src/components/analytics/TrajectoryChart.jsx
@@ -3,7 +3,17 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { cn, formatDate } from '../../lib/utils';
+import { scoreToRAG } from '../../constants/analyticsThresholds';
 import GlassCard from '../ui/GlassCard';
+
+/**
+ * Colores CSS del indicador RAG para el tooltip
+ */
+const RAG_DOT_COLORS = {
+  green: 'bg-success-base',
+  amber: 'bg-warning-base',
+  red: 'bg-error-base',
+};
 
 /**
  * Estilos del indicador de tendencia
@@ -27,8 +37,10 @@ function CustomTooltip({ active, payload, label }) {
     <div className="bg-background-elevated border border-border-default rounded-lg p-3 shadow-xl text-sm">
       <p className="text-text-muted text-xs mb-2">{label}</p>
       {studentScore && (
-        <p className="text-text-primary">
-          Alumno: <span className="font-bold tabular-nums">{Math.round(studentScore.value)}</span>
+        <p className="text-text-primary flex items-center gap-1.5">
+          Alumno:
+          <span className={cn('inline-block w-2 h-2 rounded-full', RAG_DOT_COLORS[scoreToRAG(studentScore.value)])} />
+          <span className="font-bold tabular-nums">{Math.round(studentScore.value)}</span>
         </p>
       )}
       {classScore && (
@@ -80,8 +92,10 @@ function TrajectoryChart({ trajectoryData, classComparison, title = 'Trayectoria
     return (
       <GlassCard variant="default" padding="none" className="p-5">
         <h3 className="text-base font-bold text-text-primary font-display mb-4">{title}</h3>
-        <div className="h-[250px] flex items-center justify-center">
-          <p className="text-sm text-text-muted">Se necesitan mas partidas para mostrar la trayectoria.</p>
+        <div className="h-[250px] flex items-center justify-center px-6">
+          <p className="text-text-muted text-sm text-center">
+            No hay partidas en este periodo. Cambia el rango de tiempo o espera a nuevas partidas.
+          </p>
         </div>
       </GlassCard>
     );

--- a/frontend/src/components/analytics/TrajectoryChart.jsx
+++ b/frontend/src/components/analytics/TrajectoryChart.jsx
@@ -1,0 +1,192 @@
+import { memo, useMemo } from 'react';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import PropTypes from 'prop-types';
+import { cn, formatDate } from '../../lib/utils';
+import GlassCard from '../ui/GlassCard';
+
+/**
+ * Estilos del indicador de tendencia
+ */
+const TREND_STYLES = {
+  improving: { icon: TrendingUp, label: 'Mejorando', color: 'text-success-base', bg: 'bg-success-base/10' },
+  declining: { icon: TrendingDown, label: 'Declinando', color: 'text-error-base', bg: 'bg-error-base/10' },
+  stable: { icon: Minus, label: 'Estable', color: 'text-text-muted', bg: 'bg-background-surface/50' },
+};
+
+/**
+ * Tooltip personalizado del chart
+ */
+function CustomTooltip({ active, payload, label }) {
+  if (!active || !payload?.[0]) return null;
+
+  const studentScore = payload.find(p => p.dataKey === 'score');
+  const classScore = payload.find(p => p.dataKey === 'classAverage');
+
+  return (
+    <div className="bg-background-elevated border border-border-default rounded-lg p-3 shadow-xl text-sm">
+      <p className="text-text-muted text-xs mb-2">{label}</p>
+      {studentScore && (
+        <p className="text-text-primary">
+          Alumno: <span className="font-bold tabular-nums">{Math.round(studentScore.value)}</span>
+        </p>
+      )}
+      {classScore && (
+        <p className="text-text-muted">
+          Clase: <span className="font-bold tabular-nums">{Math.round(classScore.value)}</span>
+        </p>
+      )}
+      {studentScore && classScore && (
+        <p className={cn(
+          "text-xs mt-1 font-medium",
+          studentScore.value >= classScore.value ? 'text-success-base' : 'text-error-base'
+        )}>
+          {studentScore.value >= classScore.value ? '+' : ''}
+          {Math.round(studentScore.value - classScore.value)} vs clase
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Grafico de trayectoria de aprendizaje con linea del alumno + overlay de promedio de clase.
+ * Muestra indicador de tendencia (mejorando/estable/declinando).
+ *
+ * @param {Object} props
+ * @param {Object} props.trajectoryData - Datos del endpoint /student/:id/trajectory
+ * @param {Array} [props.classComparison] - Datos de promedio de clase para overlay
+ * @param {string} [props.title] - Titulo personalizado
+ */
+function TrajectoryChart({ trajectoryData, classComparison, title = 'Trayectoria de Aprendizaje' }) {
+  const chartData = useMemo(() => {
+    if (!trajectoryData?.dataPoints) return [];
+
+    return trajectoryData.dataPoints.map((point, index) => {
+      const classPoint = classComparison?.[index];
+      return {
+        date: point.date ? formatDate(new Date(point.date), 'short') : `Punto ${index + 1}`,
+        score: point.averageScore ?? point.score ?? 0,
+        classAverage: classPoint?.averageScore ?? classPoint?.score ?? null,
+      };
+    });
+  }, [trajectoryData, classComparison]);
+
+  const trendDirection = trajectoryData?.trend?.direction || 'stable';
+  const trendStyle = TREND_STYLES[trendDirection] || TREND_STYLES.stable;
+  const TrendIcon = trendStyle.icon;
+
+  if (chartData.length === 0) {
+    return (
+      <GlassCard variant="default" padding="none" className="p-5">
+        <h3 className="text-base font-bold text-text-primary font-display mb-4">{title}</h3>
+        <div className="h-[250px] flex items-center justify-center">
+          <p className="text-sm text-text-muted">Se necesitan mas partidas para mostrar la trayectoria.</p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-bold text-text-primary font-display">{title}</h3>
+        <div className={cn("flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-semibold", trendStyle.bg, trendStyle.color)} aria-label={`Tendencia: ${trendStyle.label}`}>
+          <TrendIcon size={14} aria-hidden="true" />
+          {trendStyle.label}
+        </div>
+      </div>
+
+      {/* Leyenda */}
+      <div className="flex items-center gap-4 mb-3">
+        <div className="flex items-center gap-1.5">
+          <div className="w-4 h-0.5 bg-brand-base rounded-full" />
+          <span className="text-xs text-text-muted">Alumno</span>
+        </div>
+        {classComparison && (
+          <div className="flex items-center gap-1.5">
+            <div className="w-4 h-0.5 border-t border-dashed border-text-muted" />
+            <span className="text-xs text-text-muted">Promedio clase</span>
+          </div>
+        )}
+      </div>
+
+      <div className="h-[250px] w-full -ml-2">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+          <LineChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+            <CartesianGrid
+              stroke="var(--color-border-subtle)"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="date"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              domain={[0, 100]}
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              width={35}
+            />
+            <Tooltip content={<CustomTooltip />} />
+
+            {/* Class average (dashed line) */}
+            {classComparison && (
+              <Line
+                type="monotone"
+                dataKey="classAverage"
+                stroke="var(--color-text-muted)"
+                strokeDasharray="6 4"
+                strokeWidth={1.5}
+                dot={false}
+                connectNulls
+              />
+            )}
+
+            {/* Student score (solid line) */}
+            <Line
+              type="monotone"
+              dataKey="score"
+              stroke="var(--color-brand-base)"
+              strokeWidth={2.5}
+              dot={{ fill: 'var(--color-brand-base)', r: 3, strokeWidth: 0 }}
+              activeDot={{ r: 5, stroke: 'var(--color-brand-glow)', strokeWidth: 2 }}
+              connectNulls
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Trend confidence info */}
+      {trajectoryData?.trend?.confidence && (
+        <p className="text-xs text-text-disabled mt-2 text-right">
+          Confianza: {trajectoryData.trend.confidence}
+          {trajectoryData.trend.dataPoints && ` (${trajectoryData.trend.dataPoints} puntos)`}
+        </p>
+      )}
+    </GlassCard>
+  );
+}
+
+TrajectoryChart.propTypes = {
+  trajectoryData: PropTypes.shape({
+    dataPoints: PropTypes.arrayOf(PropTypes.shape({
+      date: PropTypes.string,
+      averageScore: PropTypes.number,
+      score: PropTypes.number,
+    })),
+    trend: PropTypes.shape({
+      direction: PropTypes.oneOf(['improving', 'declining', 'stable']),
+      confidence: PropTypes.string,
+      dataPoints: PropTypes.number,
+    }),
+  }),
+  classComparison: PropTypes.array,
+  title: PropTypes.string,
+};
+
+export default memo(TrajectoryChart);

--- a/frontend/src/components/analytics/__tests__/AnalyticsComponents.test.jsx
+++ b/frontend/src/components/analytics/__tests__/AnalyticsComponents.test.jsx
@@ -1,0 +1,478 @@
+/**
+ * @fileoverview Tests de componentes de analytics: StudentKPICard, GameHistoryTable,
+ * NarrativeCard, TrajectoryChart y EngagementRadar.
+ *
+ * Se mockean framer-motion, Recharts, GlassCard y useReducedMotion para aislar
+ * la logica de renderizado de cada componente en jsdom.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// --- Mocks globales ---
+
+vi.mock('../../../hooks/useReducedMotion', () => ({
+  useReducedMotion: () => ({ shouldReduceMotion: true }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_, tag) => {
+        const Component = (props) => {
+          const {
+            children,
+            initial,
+            animate,
+            exit,
+            variants,
+            transition,
+            whileHover,
+            whileTap,
+            layout,
+            ...rest
+          } = props;
+          const Tag = typeof tag === 'string' ? tag : 'div';
+          return <Tag {...rest}>{children}</Tag>;
+        };
+        Component.displayName = `motion.${String(tag)}`;
+        return Component;
+      },
+    }
+  ),
+  AnimatePresence: ({ children }) => <>{children}</>,
+}));
+
+vi.mock('../../ui/GlassCard', () => ({
+  default: ({ children, className, ...props }) => (
+    <div data-testid="glass-card" className={className} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  LineChart: ({ children }) => <div data-testid="line-chart">{children}</div>,
+  BarChart: ({ children }) => <div data-testid="bar-chart">{children}</div>,
+  RadarChart: ({ children }) => <div data-testid="radar-chart">{children}</div>,
+  Line: () => null,
+  Bar: () => null,
+  Radar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Cell: () => null,
+  PolarGrid: () => null,
+  PolarAngleAxis: () => null,
+  PolarRadiusAxis: () => null,
+  ReferenceLine: () => null,
+  Legend: () => null,
+}));
+
+// --- Imports de componentes bajo test ---
+
+import StudentKPICard from '../StudentKPICard';
+import GameHistoryTable from '../GameHistoryTable';
+import NarrativeCard from '../NarrativeCard';
+import TrajectoryChart from '../TrajectoryChart';
+import EngagementRadar from '../EngagementRadar';
+
+// ══════════════════════════════════════════════════════════════════════
+// StudentKPICard
+// ══════════════════════════════════════════════════════════════════════
+
+describe('StudentKPICard', () => {
+  it('renderiza el label del KPI', () => {
+    render(<StudentKPICard label="Puntuacion Media" value={85} />);
+    expect(screen.getByText('Puntuacion Media')).toBeTruthy();
+  });
+
+  it('renderiza el valor numerico', () => {
+    render(<StudentKPICard label="Score" value={72} />);
+    // AnimatedValue con shouldReduceMotion: el valor se redondea con Math.round
+    expect(screen.getByText('72')).toBeTruthy();
+  });
+
+  it('renderiza el sufijo cuando se proporciona', () => {
+    render(<StudentKPICard label="Precision" value={88} suffix="%" />);
+    // El sufijo aparece dos veces: dentro de AnimatedValue y como span separado
+    const suffixes = screen.getAllByText('%');
+    expect(suffixes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('aplica borde verde para ragStatus "green"', () => {
+    const { container } = render(
+      <StudentKPICard label="KPI" value={90} ragStatus="green" />
+    );
+    // El GlassCard recibe className con border-l-success-base
+    const card = screen.getByTestId('glass-card');
+    expect(card.className).toContain('border-l-success-base');
+  });
+
+  it('aplica borde rojo para ragStatus "red"', () => {
+    render(<StudentKPICard label="KPI" value={30} ragStatus="red" />);
+    const card = screen.getByTestId('glass-card');
+    expect(card.className).toContain('border-l-error-base');
+  });
+
+  it('aplica borde ambar para ragStatus "amber"', () => {
+    render(<StudentKPICard label="KPI" value={55} ragStatus="amber" />);
+    const card = screen.getByTestId('glass-card');
+    expect(card.className).toContain('border-l-warning-base');
+  });
+
+  it('muestra el indicador RAG dot con aria-label del estado', () => {
+    render(<StudentKPICard label="KPI" value={80} ragStatus="green" />);
+    expect(screen.getByLabelText('Estado: green')).toBeTruthy();
+  });
+
+  it('renderiza la comparativa cuando se proporciona', () => {
+    render(
+      <StudentKPICard
+        label="Score"
+        value={85}
+        comparison="vs clase: +11%"
+        comparisonPositive={true}
+      />
+    );
+    expect(screen.getByText('vs clase: +11%')).toBeTruthy();
+  });
+
+  it('renderiza el icono cuando se proporciona', () => {
+    const icon = <span data-testid="test-icon">IC</span>;
+    render(<StudentKPICard label="KPI" value={70} icon={icon} />);
+    expect(screen.getByTestId('test-icon')).toBeTruthy();
+  });
+
+  it('usa ragStatus "gray" por defecto si no se especifica', () => {
+    render(<StudentKPICard label="KPI" value={0} />);
+    const card = screen.getByTestId('glass-card');
+    expect(card.className).toContain('border-l-text-muted');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// GameHistoryTable
+// ══════════════════════════════════════════════════════════════════════
+
+describe('GameHistoryTable', () => {
+  const sampleGames = [
+    {
+      gameplayId: 'gp1',
+      score: 95,
+      correctAttempts: 9,
+      totalAttempts: 10,
+      completedAt: '2026-03-01T10:00:00Z',
+      completionTime: 150000,
+      contextName: 'Animales',
+      mechanicName: 'Emparejamiento',
+    },
+    {
+      gameplayId: 'gp2',
+      score: 45,
+      correctAttempts: 4,
+      totalAttempts: 10,
+      completedAt: '2026-03-02T14:00:00Z',
+      completionTime: 90000,
+      contextName: 'Colores',
+      mechanicName: 'Quiz',
+    },
+  ];
+
+  it('muestra mensaje vacio cuando games es null', () => {
+    render(<GameHistoryTable games={null} />);
+    expect(
+      screen.getByText('Este alumno aun no tiene partidas registradas.')
+    ).toBeTruthy();
+  });
+
+  it('muestra mensaje vacio cuando games es un array vacio', () => {
+    render(<GameHistoryTable games={[]} />);
+    expect(
+      screen.getByText('Este alumno aun no tiene partidas registradas.')
+    ).toBeTruthy();
+  });
+
+  it('renderiza el titulo "Historial de Partidas"', () => {
+    render(<GameHistoryTable games={sampleGames} />);
+    expect(screen.getByText('Historial de Partidas')).toBeTruthy();
+  });
+
+  it('muestra el contador de partidas', () => {
+    render(<GameHistoryTable games={sampleGames} />);
+    expect(screen.getByText('2 partidas')).toBeTruthy();
+  });
+
+  it('renderiza los nombres de contexto y mecanica', () => {
+    render(<GameHistoryTable games={sampleGames} />);
+    expect(screen.getByText('Animales')).toBeTruthy();
+    expect(screen.getByText('Emparejamiento')).toBeTruthy();
+    expect(screen.getByText('Colores')).toBeTruthy();
+    expect(screen.getByText('Quiz')).toBeTruthy();
+  });
+
+  it('renderiza los scores redondeados', () => {
+    render(<GameHistoryTable games={sampleGames} />);
+    expect(screen.getByText('95')).toBeTruthy();
+    expect(screen.getByText('45')).toBeTruthy();
+  });
+
+  it('calcula y muestra el porcentaje de aciertos', () => {
+    render(<GameHistoryTable games={sampleGames} />);
+    // 9/10 = 90%, 4/10 = 40%
+    expect(screen.getByText('90%')).toBeTruthy();
+    expect(screen.getByText('40%')).toBeTruthy();
+  });
+
+  it('muestra boton "Ver todas" cuando hay mas partidas que initialCount', () => {
+    // Crear 3 partidas y poner initialCount=2
+    const threeGames = [
+      ...sampleGames,
+      {
+        gameplayId: 'gp3',
+        score: 70,
+        correctAttempts: 7,
+        totalAttempts: 10,
+        contextName: 'Numeros',
+        mechanicName: 'Memoria',
+      },
+    ];
+
+    render(<GameHistoryTable games={threeGames} initialCount={2} />);
+    expect(screen.getByText(/Ver todas/)).toBeTruthy();
+  });
+
+  it('alterna entre "Ver todas" y "Mostrar menos" al hacer click', async () => {
+    const user = userEvent.setup();
+    const threeGames = [
+      ...sampleGames,
+      {
+        gameplayId: 'gp3',
+        score: 70,
+        correctAttempts: 7,
+        totalAttempts: 10,
+        contextName: 'Numeros',
+        mechanicName: 'Memoria',
+      },
+    ];
+
+    render(<GameHistoryTable games={threeGames} initialCount={2} />);
+
+    // Inicialmente muestra "Ver todas"
+    const btn = screen.getByText(/Ver todas/);
+    expect(btn).toBeTruthy();
+
+    // Tras click muestra "Mostrar menos"
+    await user.click(btn);
+    expect(screen.getByText(/Mostrar menos/)).toBeTruthy();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// NarrativeCard
+// ══════════════════════════════════════════════════════════════════════
+
+describe('NarrativeCard', () => {
+  const fullInterpretation = {
+    whatHappened: 'El alumno mejoro un 15% en la ultima semana.',
+    soWhat: 'Esto indica una tendencia positiva sostenida.',
+    nowWhat: 'Continuar con ejercicios de refuerzo avanzado.',
+  };
+
+  it('renderiza el titulo personalizado', () => {
+    render(<NarrativeCard title="Analisis Detallado" />);
+    expect(screen.getByText('Analisis Detallado')).toBeTruthy();
+  });
+
+  it('renderiza el titulo por defecto "Resumen del Alumno"', () => {
+    render(<NarrativeCard />);
+    expect(screen.getByText('Resumen del Alumno')).toBeTruthy();
+  });
+
+  it('muestra las tres secciones de la narrativa BI', () => {
+    render(<NarrativeCard interpretation={fullInterpretation} />);
+    // Labels de secciones
+    expect(screen.getByText('Que paso')).toBeTruthy();
+    expect(screen.getByText('Por que importa')).toBeTruthy();
+    expect(screen.getByText('Que hacer')).toBeTruthy();
+    // Contenido
+    expect(
+      screen.getByText('El alumno mejoro un 15% en la ultima semana.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Esto indica una tendencia positiva sostenida.')
+    ).toBeTruthy();
+    expect(
+      screen.getByText('Continuar con ejercicios de refuerzo avanzado.')
+    ).toBeTruthy();
+  });
+
+  it('muestra estado vacio cuando interpretation es null', () => {
+    render(<NarrativeCard interpretation={null} />);
+    expect(
+      screen.getByText(
+        'Se necesitan mas partidas para generar insights.'
+      )
+    ).toBeTruthy();
+  });
+
+  it('muestra estado vacio cuando interpretation no tiene datos', () => {
+    render(<NarrativeCard interpretation={{}} />);
+    expect(
+      screen.getByText(
+        'Se necesitan mas partidas para generar insights.'
+      )
+    ).toBeTruthy();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// TrajectoryChart
+// ══════════════════════════════════════════════════════════════════════
+
+describe('TrajectoryChart', () => {
+  const validTrajectory = {
+    dataPoints: [
+      { date: '2026-03-01', averageScore: 70 },
+      { date: '2026-03-02', averageScore: 80 },
+      { date: '2026-03-03', averageScore: 85 },
+    ],
+    trend: {
+      direction: 'improving',
+      confidence: 'alta',
+      dataPoints: 3,
+    },
+  };
+
+  it('muestra estado vacio cuando trajectoryData es null', () => {
+    render(<TrajectoryChart trajectoryData={null} />);
+    expect(
+      screen.getByText(/No hay partidas en este periodo/)
+    ).toBeTruthy();
+  });
+
+  it('muestra estado vacio cuando dataPoints esta vacio', () => {
+    render(<TrajectoryChart trajectoryData={{ dataPoints: [] }} />);
+    expect(
+      screen.getByText(/No hay partidas en este periodo/)
+    ).toBeTruthy();
+  });
+
+  it('renderiza el titulo personalizado', () => {
+    render(
+      <TrajectoryChart
+        trajectoryData={validTrajectory}
+        title="Progresion Semanal"
+      />
+    );
+    expect(screen.getByText('Progresion Semanal')).toBeTruthy();
+  });
+
+  it('muestra la etiqueta de tendencia "Mejorando" cuando direction es improving', () => {
+    render(<TrajectoryChart trajectoryData={validTrajectory} />);
+    expect(screen.getByText('Mejorando')).toBeTruthy();
+    expect(screen.getByLabelText('Tendencia: Mejorando')).toBeTruthy();
+  });
+
+  it('renderiza el chart cuando hay datos validos', () => {
+    render(<TrajectoryChart trajectoryData={validTrajectory} />);
+    expect(screen.getByTestId('responsive-container')).toBeTruthy();
+    expect(screen.getByTestId('line-chart')).toBeTruthy();
+  });
+
+  it('muestra la leyenda "Alumno"', () => {
+    render(<TrajectoryChart trajectoryData={validTrajectory} />);
+    expect(screen.getByText('Alumno')).toBeTruthy();
+  });
+
+  it('muestra informacion de confianza cuando esta disponible', () => {
+    render(<TrajectoryChart trajectoryData={validTrajectory} />);
+    expect(screen.getByText(/Confianza: alta/)).toBeTruthy();
+    expect(screen.getByText(/3 puntos/)).toBeTruthy();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// EngagementRadar
+// ══════════════════════════════════════════════════════════════════════
+
+describe('EngagementRadar', () => {
+  const validEngagement = {
+    engagementScore: 72,
+    components: {
+      playFrequency: 0.8,
+      regularity: 0.6,
+      completionRate: 0.9,
+      timeBetweenSessions: 0.5,
+      voluntaryReplays: 0.3,
+    },
+  };
+
+  it('muestra estado vacio cuando engagement es null', () => {
+    render(<EngagementRadar engagement={null} />);
+    expect(
+      screen.getByText(/Sin datos de engagement aun/)
+    ).toBeTruthy();
+  });
+
+  it('muestra estado vacio cuando no hay componentes', () => {
+    render(<EngagementRadar engagement={{}} />);
+    expect(
+      screen.getByText(/Sin datos de engagement aun/)
+    ).toBeTruthy();
+  });
+
+  it('renderiza el titulo "Engagement"', () => {
+    render(<EngagementRadar engagement={validEngagement} />);
+    expect(screen.getByText('Engagement')).toBeTruthy();
+  });
+
+  it('muestra el score con la etiqueta RAG correcta (Alto para >= 60)', () => {
+    render(<EngagementRadar engagement={validEngagement} />);
+    // score 72 -> "72 — Alto"
+    expect(screen.getByText(/72/)).toBeTruthy();
+    expect(screen.getByText(/Alto/)).toBeTruthy();
+  });
+
+  it('renderiza el radar chart cuando hay datos', () => {
+    render(<EngagementRadar engagement={validEngagement} />);
+    expect(screen.getByTestId('responsive-container')).toBeTruthy();
+    expect(screen.getByTestId('radar-chart')).toBeTruthy();
+  });
+
+  it('muestra etiqueta "Medio" para score entre 35 y 59', () => {
+    const mediumEngagement = {
+      engagementScore: 45,
+      components: {
+        playFrequency: 0.5,
+        regularity: 0.4,
+        completionRate: 0.5,
+        timeBetweenSessions: 0.3,
+        voluntaryReplays: 0.2,
+      },
+    };
+    render(<EngagementRadar engagement={mediumEngagement} />);
+    expect(screen.getByText(/Medio/)).toBeTruthy();
+  });
+
+  it('muestra etiqueta "Bajo" para score menor a 35', () => {
+    const lowEngagement = {
+      engagementScore: 20,
+      components: {
+        playFrequency: 0.2,
+        regularity: 0.1,
+        completionRate: 0.3,
+        timeBetweenSessions: 0.1,
+        voluntaryReplays: 0.05,
+      },
+    };
+    render(<EngagementRadar engagement={lowEngagement} />);
+    expect(screen.getByText(/Bajo/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/dashboard/AlertsPanel.jsx
+++ b/frontend/src/components/dashboard/AlertsPanel.jsx
@@ -1,70 +1,144 @@
-import { AlertTriangle, TrendingUp, CheckCircle } from 'lucide-react';
+import { AlertTriangle, TrendingUp, TrendingDown, CheckCircle, Clock, Pause, Zap, XCircle, ChevronRight } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
 import { cn, listContainerVariants, listItemVariants } from '../../lib/utils';
 import { useReducedMotion } from '../../hooks/useReducedMotion';
 
-const ALERT_CONTAINER_VARIANTS = {
-  risk: 'bg-error-base/10 border-error-base/20',
-  improvement: 'bg-success-base/10 border-success-base/20',
-  milestone: 'bg-brand-base/10 border-brand-base/20',
-  default: 'bg-background-elevated border-border-default'
+/**
+ * Mapeo de severidad a estilos visuales RAG
+ */
+const SEVERITY_STYLES = {
+  critical: {
+    container: 'bg-error-base/10 border-error-base/20',
+    icon: 'text-error-base',
+    dot: 'bg-error-base',
+  },
+  warning: {
+    container: 'bg-warning-base/10 border-warning-base/20',
+    icon: 'text-warning-base',
+    dot: 'bg-warning-base',
+  },
+  info: {
+    container: 'bg-info-base/10 border-info-base/20',
+    icon: 'text-info-base',
+    dot: 'bg-info-base',
+  },
 };
 
+/**
+ * Mapeo de tipo de alerta a icono
+ */
+const ALERT_ICONS = {
+  declining_performance: TrendingDown,
+  inactivity: Clock,
+  sudden_score_drop: AlertTriangle,
+  consistent_timeout: Pause,
+  improving_fast: TrendingUp,
+  plateau_detected: Pause,
+  high_abandonment: XCircle,
+};
+
+/**
+ * Panel de alertas inteligentes del backend.
+ * Muestra alertas con severidad RAG, accion directa al perfil del estudiante,
+ * y estado vacio positivo cuando no hay alertas.
+ *
+ * @param {Object} props
+ * @param {Array} props.alerts - Alertas del backend (de getAlerts endpoint)
+ */
 export default function AlertsPanel({ alerts }) {
   const { shouldReduceMotion } = useReducedMotion();
+  const navigate = useNavigate();
 
-  if (!alerts || alerts.length === 0) {
-    return null;
-  }
-
-  const getIcon = (type) => {
-      switch(type) {
-          case 'risk': return <AlertTriangle className="text-error-base" size={20} />;
-          case 'improvement': return <TrendingUp className="text-success-base" size={20} />;
-          case 'milestone': return <CheckCircle className="text-brand-base" size={20} />;
-          default: return <AlertTriangle className="text-text-muted" size={20} />;
-      }
-  };
+  const hasAlerts = Array.isArray(alerts) && alerts.length > 0;
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-bold text-text-primary mb-4 px-1 font-display">Alertas y Avisos</h3>
-      <motion.div
-        className="space-y-3"
-        variants={listContainerVariants(0.08)}
-        initial={shouldReduceMotion ? false : "hidden"}
-        animate="visible"
-      >
-        {alerts.map((alert, index) => (
-          <motion.div
-            key={index}
-            variants={shouldReduceMotion ? {} : listItemVariants}
-            className={cn(
-              'p-4 rounded-xl border flex items-start gap-4',
-              ALERT_CONTAINER_VARIANTS[alert.type] || ALERT_CONTAINER_VARIANTS.default
-            )}
+      <header className="flex items-center justify-between px-1">
+        <h3 className="text-lg font-bold text-text-primary font-display">Alertas Inteligentes</h3>
+        {hasAlerts && (
+          <button
+            onClick={() => navigate('/analytics/insights')}
+            className="text-xs text-brand-light hover:text-brand-base transition-colors font-medium"
           >
-            <div className="mt-1 flex-shrink-0">
-                {alert.type === 'risk' && !shouldReduceMotion ? (
-                  <motion.div
-                    animate={{ scale: [1, 1.15, 1] }}
-                    transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 1.5 }}
-                  >
-                    {getIcon(alert.type)}
-                  </motion.div>
-                ) : (
-                  getIcon(alert.type)
+            Ver todas
+          </button>
+        )}
+      </header>
+
+      {hasAlerts ? (
+        <motion.div
+          className="space-y-3"
+          variants={listContainerVariants(0.08)}
+          initial={shouldReduceMotion ? false : "hidden"}
+          animate="visible"
+        >
+          {alerts.map((alert, index) => {
+            const severity = SEVERITY_STYLES[alert.severity] || SEVERITY_STYLES.info;
+            const IconComponent = ALERT_ICONS[alert.type] || AlertTriangle;
+            const isCritical = alert.severity === 'critical';
+
+            return (
+              <motion.div
+                key={alert.id || index}
+                variants={shouldReduceMotion ? {} : listItemVariants}
+                className={cn(
+                  'p-4 rounded-xl border flex items-start gap-3 group transition-colors',
+                  severity.container,
+                  alert.studentId && 'cursor-pointer hover:border-opacity-40 focus:outline-none focus:ring-1 focus:ring-brand-base/40 focus:bg-background-surface/20'
                 )}
-            </div>
-            <div>
-                <h4 className="text-sm font-semibold text-text-primary">{alert.title}</h4>
-                <p className="text-xs text-text-muted mt-1 leading-relaxed font-medium">
-                    {alert.message}
-                </p>
-            </div>
-          </motion.div>
-        ))}
-      </motion.div>
+                onClick={alert.studentId ? () => navigate(`/students/${alert.studentId}`) : undefined}
+                role={alert.studentId ? 'button' : undefined}
+                tabIndex={alert.studentId ? 0 : undefined}
+                onKeyDown={alert.studentId ? (e) => { if (e.key === 'Enter') navigate(`/students/${alert.studentId}`); } : undefined}
+              >
+                <div className="mt-0.5 flex-shrink-0">
+                  {isCritical && !shouldReduceMotion ? (
+                    <motion.div
+                      animate={{ scale: [1, 1.15, 1] }}
+                      transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 2 }}
+                    >
+                      <IconComponent className={severity.icon} size={18} aria-hidden="true" />
+                    </motion.div>
+                  ) : (
+                    <IconComponent className={severity.icon} size={18} aria-hidden="true" />
+                  )}
+                </div>
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h4 className="text-sm font-semibold text-text-primary truncate">
+                      {alert.studentName || alert.title}
+                    </h4>
+                    <span className={cn("size-1.5 rounded-full flex-shrink-0", severity.dot)} aria-hidden="true" />
+                  </div>
+                  <p className="text-xs text-text-muted mt-0.5 leading-relaxed font-medium line-clamp-2">
+                    {alert.message || alert.description}
+                  </p>
+                </div>
+
+                {alert.studentId && (
+                  <ChevronRight
+                    size={14}
+                    className="text-text-muted/30 group-hover:text-text-muted mt-1 flex-shrink-0 transition-colors"
+                    aria-hidden="true"
+                  />
+                )}
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      ) : (
+        <motion.div
+          initial={shouldReduceMotion ? false : { opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="p-6 rounded-xl border border-success-base/20 bg-success-base/5 text-center"
+        >
+          <CheckCircle className="text-success-base mx-auto mb-2" size={28} aria-hidden="true" />
+          <p className="text-sm font-semibold text-text-primary">Todo marcha bien</p>
+          <p className="text-xs text-text-muted mt-1">No hay alertas activas en este momento.</p>
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/ClassroomOverview.jsx
+++ b/frontend/src/components/dashboard/ClassroomOverview.jsx
@@ -1,27 +1,25 @@
 import DistributionChart from './DistributionChart';
 import ChartSection from './ChartSection';
+import { SkeletonChart } from '../ui/SkeletonShimmer';
 
-// Este componente ahora es más sencillo porque la lógica de distribución
-// podría venir del backend o calcularse aquí.
-// Por ahora reutilizamos DistributionChart con datos reales o calculados.
-
+/**
+ * Vista de distribucion de rendimiento de la clase con KPIs resumidos.
+ * Consume datos reales del endpoint /classroom/distribution.
+ * @param {Object} props
+ * @param {Object} props.summary - KPIs resumidos (averageScore, totalGames, gamesToday)
+ * @param {Array} props.distribution - Distribucion [{range, count, percentage}] del backend
+ */
 export default function ClassroomOverview({ summary, distribution }) {
-    // Si no tenemos distribución real del backend, podemos inferirla o mostrar loading
-    // Por simplicidad, asumimos que 'distribution' se pasa calculado desde el Dashboard
-    // o usamos datos placeholder si no está disponible, pero idealmente debería ser real.
-
-    // Mock fallback si no hay distribution data calculada
-    const safeDistribution = distribution || [
-        { range: '0-49', count: 0 },
-        { range: '50-69', count: 0 },
-        { range: '70-89', count: 0 },
-        { range: '90-100', count: 0 },
-    ];
+    const hasDistribution = Array.isArray(distribution) && distribution.length > 0;
 
     return (
-        <ChartSection title="Distribución de Rendimiento Global">
+        <ChartSection title="Distribucion de Rendimiento Global">
             <div className="h-[200px] sm:h-[240px] w-full mt-2 -ml-4 sm:ml-0">
-               <DistributionChart data={safeDistribution} />
+               {hasDistribution ? (
+                 <DistributionChart data={distribution} />
+               ) : (
+                 <SkeletonChart height={200} />
+               )}
             </div>
             <div className="grid grid-cols-3 gap-4 mt-8 pt-6 border-t border-border-default">
                 <div className="text-center">

--- a/frontend/src/components/dashboard/DifficultyHeatmap.jsx
+++ b/frontend/src/components/dashboard/DifficultyHeatmap.jsx
@@ -43,7 +43,9 @@ export default function DifficultyHeatmap({ data }) {
 
   return (
     <ChartSection title="Mapa de Calor de Dificultad">
-      <div className="h-[300px] w-full">
+      {/* Contenedor con scroll horizontal para viewports pequenos */}
+      <div className="overflow-x-auto">
+      <div className="h-[300px] w-full min-w-[480px]">
         <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
           <ScatterChart margin={{ top: 20, right: 20, bottom: 40, left: 20 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-subtle)" />
@@ -89,6 +91,7 @@ export default function DifficultyHeatmap({ data }) {
             </Scatter>
           </ScatterChart>
         </ResponsiveContainer>
+      </div>
       </div>
       <p className="text-xs text-text-muted mt-6 text-center font-medium">
         Identifica qué combinaciones de <strong>Contexto + Mecánica</strong> generan más errores.

--- a/frontend/src/components/dashboard/StudentsList.jsx
+++ b/frontend/src/components/dashboard/StudentsList.jsx
@@ -1,37 +1,65 @@
 import { memo } from 'react';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { staggerItem, cn } from '../../lib/utils';
-import { useAuth } from '../../context/AuthContext';
-import { ROUTES } from '../../constants/routes';
-
-// Mock Data temporarily here, eventually from props or API
-const studentProgressData = [
-  { id: 1, name: 'Alex Johnson', progress: 92, status: 'Activo', avatar: '🦊' },
-  { id: 2, name: 'Sarah Williams', progress: 88, status: 'Activo', avatar: '🐰' },
-  { id: 3, name: 'Michael Brown', progress: 76, status: 'Desconectado', avatar: '🐻' },
-  { id: 4, name: 'Emily Davis', progress: 95, status: 'Activo', avatar: '🦋' },
-  { id: 5, name: 'James Wilson', progress: 62, status: 'Desconectado', avatar: '🐢' },
-];
 
 /**
- * Obtiene la clase de color según el progreso del estudiante
- * @param {number} progress - Porcentaje de progreso (0-100)
- * @returns {string} Clase de Tailwind para el color
+ * Obtiene el color RAG segun el tier del estudiante
+ * @param {string} tier - risk | average | good | excellent
+ * @returns {string} Clases de Tailwind para el color
  */
-const getProgressColorClass = (progress) => {
-  if (progress >= 90) return "text-success-base";
-  if (progress >= 70) return "text-warning-base";
-  return "text-text-muted";
+const getTierColor = (tier) => {
+  switch (tier) {
+    case 'excellent': return 'text-success-base';
+    case 'good': return 'text-success-base/80';
+    case 'average': return 'text-warning-base';
+    case 'risk': return 'text-error-base';
+    default: return 'text-text-muted';
+  }
 };
 
-function StudentsList({ students = studentProgressData }) {
-  const { isSuperAdmin } = useAuth();
+/**
+ * Obtiene el badge de rendimiento segun el tier
+ * @param {string} tier - risk | average | good | excellent
+ * @returns {{ label: string, className: string }}
+ */
+const getTierBadge = (tier) => {
+  switch (tier) {
+    case 'excellent': return { label: 'Excelente', className: 'bg-success-base/15 text-success-base' };
+    case 'good': return { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80' };
+    case 'average': return { label: 'Promedio', className: 'bg-warning-base/15 text-warning-base' };
+    case 'risk': return { label: 'En riesgo', className: 'bg-error-base/15 text-error-base' };
+    default: return { label: '—', className: 'bg-background-surface/50 text-text-muted' };
+  }
+};
+
+/**
+ * Genera las iniciales del nombre para el avatar fallback
+ * @param {string} name - Nombre completo
+ * @returns {string} Iniciales (max 2 caracteres)
+ */
+const getInitials = (name) => {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+/**
+ * Lista de los mejores estudiantes del profesor con datos reales de la API.
+ * Muestra top 5 con score, tier badge y navegacion al perfil.
+ * @param {Object} props
+ * @param {Array} [props.students] - Lista de estudiantes del endpoint /classroom/students
+ */
+function StudentsList({ students }) {
   const navigate = useNavigate();
+  const topStudents = students?.slice(0, 5) || [];
+  const hasStudents = topStudents.length > 0;
 
   return (
-    <motion.section 
+    <motion.section
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.3 }}
@@ -46,85 +74,103 @@ function StudentsList({ students = studentProgressData }) {
     >
       {/* Top highlight */}
       <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" aria-hidden="true" />
-      
+
       <header className="flex items-center justify-between mb-6">
         <h3 id="students-list-title" className="text-xl font-bold text-text-primary font-display">Mejores Estudiantes</h3>
-        <span className="text-xs text-text-muted bg-background-surface/50 px-2 py-1 rounded-lg" aria-label="Mostrando top 5">Top 5</span>
+        <span className="text-xs text-text-muted bg-background-surface/50 px-2 py-1 rounded-lg" aria-label={`Mostrando top ${topStudents.length}`}>
+          Top {topStudents.length}
+        </span>
       </header>
 
-      <ol 
-        aria-label="Lista de mejores estudiantes"
-        className="space-y-3"
-      >
-        {students.map((student, index) => (
-          <motion.li 
-            key={student.id} 
-            variants={staggerItem}
-            whileHover={{ x: 4, backgroundColor: 'rgba(255,255,255,0.05)' }}
-            className="flex items-center justify-between p-3 rounded-xl transition-colors duration-200 group cursor-pointer list-none"
-          >
-            <div className="flex items-center gap-3">
-              {/* Rank Badge */}
-              <span 
-                className={cn(
-                  "size-6 rounded-lg flex items-center justify-center text-xs font-bold",
-                  index === 0 && "bg-warning-base/20 text-warning-base",
-                  index === 1 && "bg-text-muted/10 text-text-muted",
-                  index === 2 && "bg-error-base/20 text-error-base",
-                  index > 2 && "bg-background-surface/50 text-text-muted"
-                )}
-                aria-label={`Posición ${index + 1}`}
+      {hasStudents ? (
+        <ol aria-label="Lista de mejores estudiantes" className="space-y-3">
+          {topStudents.map((student, index) => {
+            const tierBadge = getTierBadge(student.tier);
+            return (
+              <motion.li
+                key={student.studentId || student._id || index}
+                variants={staggerItem}
+                whileHover={{ x: 4, backgroundColor: 'rgba(255,255,255,0.05)' }}
+                onClick={() => navigate(`/students/${student.studentId || student._id}`)}
+                className="flex items-center justify-between p-3 rounded-xl transition-colors duration-200 group cursor-pointer list-none focus:outline-none focus:ring-1 focus:ring-brand-base/40 focus:bg-background-surface/20"
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/students/${student.studentId || student._id}`); }}
+                aria-label={`${student.name}, puntuacion ${Math.round(student.averageScore || 0)}`}
               >
-                {index + 1}
-              </span>
-              
-              {/* Avatar */}
-              <div 
-                className="size-10 rounded-full bg-gradient-to-br from-accent-indigo to-brand-base flex items-center justify-center text-lg shadow-lg group-hover:scale-105 transition-transform"
-                aria-label={`Avatar de ${student.name}`}
-              >
-                <span aria-hidden="true">{student.avatar}</span>
-              </div>
-              
-              <div>
-                <div className="text-text-primary font-medium group-hover:text-brand-light transition-colors">{student.name}</div>
-                <div className="flex items-center gap-2">
-                  <span 
+                <div className="flex items-center gap-3">
+                  {/* Rank Badge */}
+                  <span
                     className={cn(
-                      "size-1.5 rounded-full",
-                      student.status === 'Activo' ? "bg-success-base" : "bg-text-muted"
-                    )} 
-                    aria-hidden="true"
-                  />
-                  <span className="text-xs text-text-muted">{student.status}</span>
-                </div>
-              </div>
-            </div>
-            
-            <div className="text-right">
-              <div 
-                className={cn(
-                  "font-bold tabular-nums",
-                  getProgressColorClass(student.progress)
-                )}
-                aria-label={`Progreso: ${student.progress}%`}
-              >
-                {student.progress}%
-              </div>
-            </div>
-          </motion.li>
-        ))}
-      </ol>
+                      "size-6 rounded-lg flex items-center justify-center text-xs font-bold",
+                      index === 0 && "bg-warning-base/20 text-warning-base",
+                      index === 1 && "bg-text-muted/10 text-text-muted",
+                      index === 2 && "bg-error-base/20 text-error-base",
+                      index > 2 && "bg-background-surface/50 text-text-muted"
+                    )}
+                    aria-label={`Posicion ${index + 1}`}
+                  >
+                    {index + 1}
+                  </span>
 
-      {isSuperAdmin && (
-        <motion.button 
+                  {/* Avatar */}
+                  <div
+                    className="size-10 rounded-full bg-gradient-to-br from-accent-indigo to-brand-base flex items-center justify-center text-sm font-bold text-white shadow-lg group-hover:scale-105 transition-transform"
+                    aria-label={`Avatar de ${student.name}`}
+                  >
+                    {student.avatar ? (
+                      <img src={student.avatar} alt="" className="size-full rounded-full object-cover" />
+                    ) : (
+                      <span aria-hidden="true">{getInitials(student.name)}</span>
+                    )}
+                  </div>
+
+                  <div className="min-w-0">
+                    <div className="text-text-primary font-medium group-hover:text-brand-light transition-colors truncate">
+                      {student.name}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className={cn("text-[10px] font-semibold px-1.5 py-0.5 rounded-md", tierBadge.className)}>
+                        {tierBadge.label}
+                      </span>
+                      {student.classroom && (
+                        <span className="text-xs text-text-muted">{student.classroom}</span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <div className="text-right">
+                    <div
+                      className={cn("font-bold tabular-nums", getTierColor(student.tier))}
+                    >
+                      {Math.round(student.averageScore || 0)}
+                    </div>
+                    <div className="text-[10px] text-text-muted">pts</div>
+                  </div>
+                  <ChevronRight size={14} className="text-text-muted/30 group-hover:text-text-muted transition-colors" aria-hidden="true" />
+                </div>
+              </motion.li>
+            );
+          })}
+        </ol>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <p className="text-text-muted text-sm">Aun no hay datos de estudiantes.</p>
+          <p className="text-text-disabled text-xs mt-1">Los datos apareceran cuando los alumnos jueguen partidas.</p>
+        </div>
+      )}
+
+      {hasStudents && students?.length > 5 && (
+        <motion.button
           whileHover={{ scale: 1.02 }}
           whileTap={{ scale: 0.98 }}
-          onClick={() => navigate(ROUTES.STUDENT_MANAGEMENT)}
+          onClick={() => navigate('/analytics/students')}
           className="w-full mt-6 py-3 rounded-xl border border-dashed border-border-default text-text-muted hover:text-text-primary hover:border-brand-base/50 hover:bg-brand-base/5 transition-[color,background-color,border-color] duration-300 focus:outline-none focus:ring-2 focus:ring-brand-base/50 text-sm font-medium"
-          aria-label="Ir a gestión de alumnos"
+          aria-label="Ver todos los alumnos"
         >
-          Gestionar Todos los Alumnos
+          Ver todos los alumnos ({students.length})
         </motion.button>
       )}
     </motion.section>
@@ -133,11 +179,13 @@ function StudentsList({ students = studentProgressData }) {
 
 StudentsList.propTypes = {
   students: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
+    studentId: PropTypes.string,
+    _id: PropTypes.string,
     name: PropTypes.string.isRequired,
-    progress: PropTypes.number.isRequired,
-    status: PropTypes.string.isRequired,
+    averageScore: PropTypes.number,
+    tier: PropTypes.oneOf(['risk', 'average', 'good', 'excellent']),
     avatar: PropTypes.string,
+    classroom: PropTypes.string,
   })),
 };
 

--- a/frontend/src/constants/__tests__/analyticsThresholds.test.js
+++ b/frontend/src/constants/__tests__/analyticsThresholds.test.js
@@ -1,0 +1,218 @@
+/**
+ * @fileoverview Tests unitarios para el modulo de umbrales de analytics.
+ *
+ * Cubre las constantes PERFORMANCE_TIERS, TIER_CONFIG y TIER_BADGE,
+ * asi como las funciones de clasificacion scoreToTier, scoreToRAG,
+ * getRAGCSSColor y scoreToRAGWithNull.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  PERFORMANCE_TIERS,
+  TIER_CONFIG,
+  TIER_BADGE,
+  scoreToTier,
+  scoreToRAG,
+  getRAGCSSColor,
+  scoreToRAGWithNull,
+} from '../analyticsThresholds';
+
+// ──────────────────────────────────────────────────────────────────────
+// Constantes
+// ──────────────────────────────────────────────────────────────────────
+
+describe('PERFORMANCE_TIERS', () => {
+  it('debe contener exactamente 4 tiers', () => {
+    expect(PERFORMANCE_TIERS).toHaveLength(4);
+  });
+
+  it('debe cubrir el rango completo 0-100 sin huecos', () => {
+    const sorted = [...PERFORMANCE_TIERS].sort((a, b) => a.min - b.min);
+
+    expect(sorted[0].min).toBe(0);
+    expect(sorted[sorted.length - 1].max).toBe(100);
+
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i].min).toBe(sorted[i - 1].max + 1);
+    }
+  });
+
+  it('debe incluir los tiers risk, average, good y excellent', () => {
+    const tierNames = PERFORMANCE_TIERS.map((t) => t.tier);
+    expect(tierNames).toContain('risk');
+    expect(tierNames).toContain('average');
+    expect(tierNames).toContain('good');
+    expect(tierNames).toContain('excellent');
+  });
+});
+
+describe('TIER_CONFIG', () => {
+  it('debe tener las 4 claves de tier', () => {
+    expect(Object.keys(TIER_CONFIG)).toEqual(
+      expect.arrayContaining(['excellent', 'good', 'average', 'risk'])
+    );
+  });
+
+  it('cada tier debe tener label y className', () => {
+    for (const key of Object.keys(TIER_CONFIG)) {
+      expect(TIER_CONFIG[key]).toHaveProperty('label');
+      expect(TIER_CONFIG[key]).toHaveProperty('className');
+      expect(typeof TIER_CONFIG[key].label).toBe('string');
+      expect(typeof TIER_CONFIG[key].className).toBe('string');
+    }
+  });
+});
+
+describe('TIER_BADGE', () => {
+  it('debe tener las 4 claves de tier', () => {
+    expect(Object.keys(TIER_BADGE)).toEqual(
+      expect.arrayContaining(['excellent', 'good', 'average', 'risk'])
+    );
+  });
+
+  it('risk debe tener label "Bajo" y average "Medio"', () => {
+    expect(TIER_BADGE.risk.label).toBe('Bajo');
+    expect(TIER_BADGE.average.label).toBe('Medio');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// scoreToTier
+// ──────────────────────────────────────────────────────────────────────
+
+describe('scoreToTier', () => {
+  // Valores nulos e invalidos
+  it('debe devolver "risk" para null', () => {
+    expect(scoreToTier(null)).toBe('risk');
+  });
+
+  it('debe devolver "risk" para undefined', () => {
+    expect(scoreToTier(undefined)).toBe('risk');
+  });
+
+  it('debe devolver "risk" para valores negativos', () => {
+    expect(scoreToTier(-1)).toBe('risk');
+    expect(scoreToTier(-100)).toBe('risk');
+  });
+
+  // Boundaries exactos
+  it('debe devolver "risk" para 0', () => {
+    expect(scoreToTier(0)).toBe('risk');
+  });
+
+  it('debe devolver "risk" para 49', () => {
+    expect(scoreToTier(49)).toBe('risk');
+  });
+
+  it('debe devolver "average" para 50', () => {
+    expect(scoreToTier(50)).toBe('average');
+  });
+
+  it('debe devolver "average" para 69', () => {
+    expect(scoreToTier(69)).toBe('average');
+  });
+
+  it('debe devolver "good" para 70', () => {
+    expect(scoreToTier(70)).toBe('good');
+  });
+
+  it('debe devolver "good" para 89', () => {
+    expect(scoreToTier(89)).toBe('good');
+  });
+
+  it('debe devolver "excellent" para 90', () => {
+    expect(scoreToTier(90)).toBe('excellent');
+  });
+
+  it('debe devolver "excellent" para 100', () => {
+    expect(scoreToTier(100)).toBe('excellent');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// scoreToRAG
+// ──────────────────────────────────────────────────────────────────────
+
+describe('scoreToRAG', () => {
+  it('debe devolver "red" para null', () => {
+    expect(scoreToRAG(null)).toBe('red');
+  });
+
+  it('debe devolver "red" para undefined', () => {
+    expect(scoreToRAG(undefined)).toBe('red');
+  });
+
+  it('debe devolver "red" para scores < 50', () => {
+    expect(scoreToRAG(0)).toBe('red');
+    expect(scoreToRAG(49)).toBe('red');
+  });
+
+  it('debe devolver "amber" para scores entre 50 y 69', () => {
+    expect(scoreToRAG(50)).toBe('amber');
+    expect(scoreToRAG(69)).toBe('amber');
+  });
+
+  it('debe devolver "green" para scores >= 70', () => {
+    expect(scoreToRAG(70)).toBe('green');
+    expect(scoreToRAG(100)).toBe('green');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// getRAGCSSColor
+// ──────────────────────────────────────────────────────────────────────
+
+describe('getRAGCSSColor', () => {
+  it('debe devolver color de error para scores < 50', () => {
+    expect(getRAGCSSColor(0)).toBe('var(--color-error-base)');
+    expect(getRAGCSSColor(49)).toBe('var(--color-error-base)');
+  });
+
+  it('debe devolver color de warning para scores entre 50 y 69', () => {
+    expect(getRAGCSSColor(50)).toBe('var(--color-warning-base)');
+    expect(getRAGCSSColor(69)).toBe('var(--color-warning-base)');
+  });
+
+  it('debe devolver color de success para scores >= 70', () => {
+    expect(getRAGCSSColor(70)).toBe('var(--color-success-base)');
+    expect(getRAGCSSColor(100)).toBe('var(--color-success-base)');
+  });
+
+  it('debe devolver color de success para el boundary exacto 90', () => {
+    expect(getRAGCSSColor(90)).toBe('var(--color-success-base)');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// scoreToRAGWithNull
+// ──────────────────────────────────────────────────────────────────────
+
+describe('scoreToRAGWithNull', () => {
+  it('debe devolver "gray" para null', () => {
+    expect(scoreToRAGWithNull(null)).toBe('gray');
+  });
+
+  it('debe devolver "gray" para undefined', () => {
+    expect(scoreToRAGWithNull(undefined)).toBe('gray');
+  });
+
+  it('debe devolver "gray" para NaN', () => {
+    expect(scoreToRAGWithNull(NaN)).toBe('gray');
+  });
+
+  it('debe devolver "red" para scores < 50', () => {
+    expect(scoreToRAGWithNull(0)).toBe('red');
+    expect(scoreToRAGWithNull(49)).toBe('red');
+  });
+
+  it('debe devolver "amber" para scores entre 50 y 69', () => {
+    expect(scoreToRAGWithNull(50)).toBe('amber');
+    expect(scoreToRAGWithNull(69)).toBe('amber');
+  });
+
+  it('debe devolver "green" para scores >= 70', () => {
+    expect(scoreToRAGWithNull(70)).toBe('green');
+    expect(scoreToRAGWithNull(100)).toBe('green');
+  });
+});

--- a/frontend/src/constants/analyticsThresholds.js
+++ b/frontend/src/constants/analyticsThresholds.js
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Fuente única de verdad para umbrales RAG y tiers de rendimiento
+ * en el frontend de analytics.
+ *
+ * Estos valores reflejan los definidos en el backend:
+ *   backend/src/services/analytics/analyticsHelpers.js → PERFORMANCE_TIERS, KPI_DEFINITIONS
+ *
+ * Si los umbrales cambian en el backend, deben actualizarse aquí también.
+ */
+
+// ══════════════════════════════════════════════════════════════════════
+// Performance Tiers (coinciden con backend analyticsHelpers.js)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Rangos de rendimiento con boundaries, labels y clases Tailwind.
+ */
+export const PERFORMANCE_TIERS = [
+  { tier: 'risk', label: 'Necesita apoyo', min: 0, max: 49 },
+  { tier: 'average', label: 'Promedio', min: 50, max: 69 },
+  { tier: 'good', label: 'Bueno', min: 70, max: 89 },
+  { tier: 'excellent', label: 'Excelente', min: 90, max: 100 },
+];
+
+/**
+ * Configuración visual de cada tier para badges y cards.
+ */
+export const TIER_CONFIG = {
+  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base border-success-base/30' },
+  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80 border-success-base/20' },
+  average: { label: 'Promedio', className: 'bg-warning-base/15 text-warning-base border-warning-base/30' },
+  risk: { label: 'Necesita apoyo', className: 'bg-error-base/15 text-error-base border-error-base/30' },
+};
+
+/**
+ * Badges compactos para tablas e historial de partidas.
+ */
+export const TIER_BADGE = {
+  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base' },
+  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80' },
+  average: { label: 'Medio', className: 'bg-warning-base/15 text-warning-base' },
+  risk: { label: 'Bajo', className: 'bg-error-base/15 text-error-base' },
+};
+
+// ══════════════════════════════════════════════════════════════════════
+// Funciones de clasificación
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Clasifica un score (0-100) en un tier de rendimiento.
+ * @param {number|null|undefined} score
+ * @returns {'excellent'|'good'|'average'|'risk'}
+ */
+export function scoreToTier(score) {
+  if (score == null || score < 0) return 'risk';
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  return 'risk';
+}
+
+/**
+ * Mapea un score a color RAG semántico (green/amber/red).
+ * @param {number|null|undefined} score
+ * @returns {'green'|'amber'|'red'}
+ */
+export function scoreToRAG(score) {
+  if (score == null) return 'red';
+  if (score >= 70) return 'green';
+  if (score >= 50) return 'amber';
+  return 'red';
+}
+
+/**
+ * Devuelve un CSS custom property de color según el score.
+ * Para uso en charts de Recharts que necesitan color inline.
+ * @param {number} score
+ * @returns {string} CSS variable
+ */
+export function getRAGCSSColor(score) {
+  if (score >= 70) return 'var(--color-success-base)';
+  if (score >= 50) return 'var(--color-warning-base)';
+  return 'var(--color-error-base)';
+}
+
+/**
+ * Mapea un score a color RAG con soporte para null/NaN → 'gray'.
+ * Pensado para matrices y celdas que pueden no tener datos.
+ * @param {number|null|undefined} score
+ * @returns {'green'|'amber'|'red'|'gray'}
+ */
+export function scoreToRAGWithNull(score) {
+  if (score == null || isNaN(score)) return 'gray';
+  if (score >= 70) return 'green';
+  if (score >= 50) return 'amber';
+  return 'red';
+}

--- a/frontend/src/constants/routes.js
+++ b/frontend/src/constants/routes.js
@@ -17,6 +17,7 @@ export const ROUTES = {
   GAME: (sessionId) => `/game/${sessionId}`,
 
   // Alumnos
+  STUDENT_PROFILE: (studentId) => `/students/${studentId}`,
   STUDENT_TRANSFER: '/students/transfer',
 
   // Sesiones
@@ -34,6 +35,10 @@ export const ROUTES = {
   CARD_DECKS_DETAIL: (deckId) => `/decks/${deckId}`,
   CARD_DECKS_EDIT: (deckId) => `/decks/${deckId}/edit`,
   
+  // Analytics
+  STUDENTS_ANALYTICS: '/analytics/students',
+  INSIGHTS: '/analytics/insights',
+
   // Admin (solo super_admin)
   ADMIN_APPROVALS: '/admin/approvals',
   STUDENT_MANAGEMENT: '/admin/students',
@@ -47,6 +52,16 @@ export const NAV_ROUTES = [
     path: ROUTES.DASHBOARD,
     label: 'Dashboard',
     icon: 'LayoutDashboard',
+  },
+  {
+    path: ROUTES.STUDENTS_ANALYTICS,
+    label: 'Mis Alumnos',
+    icon: 'Users',
+  },
+  {
+    path: ROUTES.INSIGHTS,
+    label: 'Insights',
+    icon: 'TrendingUp',
   },
   {
     path: ROUTES.SESSIONS,

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -314,3 +314,37 @@ export const shakeAnimation = {
   x: [-4, 4, -3, 3, -1, 1, 0],
   transition: { duration: 0.4 },
 };
+
+/**
+ * Exporta datos a CSV y descarga el archivo.
+ * Generacion client-side con Blob + URL.createObjectURL (sin dependencias externas).
+ * @param {Array<Object>} data - Array de objetos a exportar
+ * @param {string} filename - Nombre del archivo (sin extension)
+ * @param {Array<{key: string, label: string}>} columns - Columnas a incluir
+ */
+export function exportToCSV(data, filename, columns) {
+  if (!data?.length || !columns?.length) return;
+
+  const separator = ',';
+  const header = columns.map(c => `"${c.label}"`).join(separator);
+  const rows = data.map(row =>
+    columns.map(c => {
+      const val = row[c.key];
+      if (val == null) return '""';
+      const str = String(val).replace(/"/g, '""');
+      return `"${str}"`;
+    }).join(separator)
+  );
+
+  const csv = [header, ...rows].join('\n');
+  const BOM = '\uFEFF';
+  const blob = new Blob([BOM + csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${filename}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Users, Gamepad2, Trophy, AlertTriangle, Calendar, CalendarClock, Layers, ChevronRight } from 'lucide-react';
+import { Users, Gamepad2, Trophy, AlertTriangle, Calendar, CalendarClock, Layers, ChevronRight, Target, Clock, UserCheck, CheckCircle2 } from 'lucide-react';
 import ErrorState from '../components/ui/ErrorState';
 import { listContainerVariants, listItemVariants, crossfadeVariants, formatDate } from '../lib/utils';
 import { useDocumentTitle } from '../hooks/useDocumentTitle';
@@ -17,6 +17,8 @@ import StudentProgressChart from '../components/dashboard/StudentProgressChart';
 import ClassroomOverview from '../components/dashboard/ClassroomOverview';
 import AlertsPanel from '../components/dashboard/AlertsPanel';
 import DifficultyHeatmap from '../components/dashboard/DifficultyHeatmap';
+import StudentsList from '../components/dashboard/StudentsList';
+import ActivityHeatmap from '../components/analytics/ActivityHeatmap';
 import SkeletonShimmer, { SkeletonCard, SkeletonStatCard, SkeletonChart } from '../components/ui/SkeletonShimmer';
 import SelectPremium from '../components/ui/SelectPremium';
 import ButtonPremium from '../components/ui/ButtonPremium';
@@ -26,7 +28,7 @@ export default function Dashboard() {
   const navigate = useNavigate();
   useDocumentTitle('Dashboard');
   const { shouldReduceMotion } = useReducedMotion();
-  const [timeRange, setTimeRange] = useState('7d'); // '7d' or '30d'
+  const [timeRange, setTimeRange] = useState('7d');
 
   // Redirigir super_admin a su panel
   useEffect(() => {
@@ -40,6 +42,10 @@ export default function Dashboard() {
   const [trends, setTrends] = useState(null);
   const [progressData, setProgressData] = useState([]);
   const [difficulties, setDifficulties] = useState([]);
+  const [studentsData, setStudentsData] = useState(null);
+  const [distributionData, setDistributionData] = useState(null);
+  const [alertsData, setAlertsData] = useState(null);
+  const [heatmapData, setHeatmapData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const dataAbortRef = useRef(null);
@@ -52,17 +58,27 @@ export default function Dashboard() {
     const run = async () => {
       try {
         setLoading(true);
-        const [summaryData, trendsData, progress, difficultiesData] = await Promise.all([
+        // Summary y Trends son criticos (KPIs principales). El resto son secundarios:
+        // si fallan, la pagina sigue funcionando con datos parciales.
+        const [summaryData, trendsData, progress, difficultiesData, students, distribution, alerts, heatmap] = await Promise.all([
           analyticsService.getClassroomSummary({ signal: controller.signal }),
           analyticsService.getClassroomTrends(timeRange, { signal: controller.signal }),
-          analyticsService.getClassroomComparison(timeRange, { signal: controller.signal }),
-          analyticsService.getClassroomDifficulties({ signal: controller.signal })
+          analyticsService.getClassroomComparison(timeRange, { signal: controller.signal }).catch(() => []),
+          analyticsService.getClassroomDifficulties({ signal: controller.signal }).catch(() => []),
+          analyticsService.getClassroomStudents({ sort: 'score', order: 'desc' }, { signal: controller.signal }).catch(() => null),
+          analyticsService.getClassroomDistribution({}, { signal: controller.signal }).catch(() => null),
+          analyticsService.getAlerts({ limit: 5 }, { signal: controller.signal }).catch(() => null),
+          analyticsService.getClassroomHeatmap(timeRange, { signal: controller.signal }).catch(() => null)
         ]);
 
         setSummary(summaryData);
         setTrends(trendsData);
         setProgressData(progress);
         setDifficulties(difficultiesData);
+        setStudentsData(students);
+        setDistributionData(distribution);
+        setAlertsData(alerts);
+        setHeatmapData(heatmap);
         setError(null);
       } catch (err) {
         if (isAbortError(err)) return;
@@ -99,27 +115,33 @@ export default function Dashboard() {
     return `${sign}${kpi.changePercent}%`;
   }, [trends]);
 
+  // Obtener el valor actual de un KPI desde trends
+  const getKPIValue = useCallback((kpiName) => {
+    if (!trends?.kpis) return null;
+    const kpi = trends.kpis.find(k => k.name === kpiName);
+    return kpi?.current ?? null;
+  }, [trends]);
+
   const periodLabel = timeRange === '30d' ? 'vs mes anterior' : 'vs semana pasada';
 
-  // Derivar alertas de los datos - Memoized to prevent recalculation on unrelated re-renders
-  const alerts = useMemo(() => {
-    const arr = [];
-    if (summary?.studentsInRisk > 0) {
-        arr.push({
-            type: 'risk',
-            title: 'Alumnos en Riesgo',
-            message: `${summary.studentsInRisk} alumnos tienen un promedio bajo (<50) en sus últimas partidas.`
-        });
-    }
-    if (summary?.gamesToday > 5) {
-        arr.push({
-            type: 'milestone',
-            title: 'Alta Actividad',
-            message: `Hoy ha sido un día muy activo con ${summary.gamesToday} partidas jugadas.`
-        });
-    }
-    return arr;
-  }, [summary]);
+  // Derivar contadores de estudiantes activos
+  const activeStudentsCount = useMemo(() => {
+    if (!studentsData?.students) return 0;
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    return studentsData.students.filter(s => {
+      if (!s.lastPlayedAt) return false;
+      return new Date(s.lastPlayedAt) >= sevenDaysAgo;
+    }).length;
+  }, [studentsData]);
+
+  const totalStudents = studentsData?.students?.length || 0;
+
+  // Alertas inteligentes del backend (reemplaza la derivacion client-side)
+  const backendAlerts = useMemo(() => {
+    if (!alertsData?.alerts) return [];
+    return alertsData.alerts;
+  }, [alertsData]);
 
   // Prevenir Layout Shifts (CLS) renderizando una estructura idéntica durante la carga
   const skeletonContent = loading && !summary;
@@ -146,7 +168,7 @@ export default function Dashboard() {
 
           {/* KPIs Skeleton */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6">
-            {[...Array(4)].map((_, index) => (
+            {[...Array(8)].map((_, index) => (
               <SkeletonStatCard key={`stat-skeleton-${index}`} />
             ))}
           </div>
@@ -242,6 +264,51 @@ export default function Dashboard() {
                     color="bg-gradient-to-br from-info-base to-accent-cyan"
                   />
                 </motion.div>
+
+                {/* Fila 2: KPIs secundarios */}
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <StatCard
+                    title="Tasa de Acierto"
+                    value={`${getKPIValue('averageAccuracy') ?? summary?.averageAccuracy ?? 0}%`}
+                    trend={getTrend('averageAccuracy')}
+                    periodLabel={periodLabel}
+                    icon={<Target className="text-white drop-shadow-sm" size={24} aria-hidden="true" />}
+                    color="bg-gradient-to-br from-accent-cyan to-info-base"
+                  />
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <StatCard
+                    title="Tiempo Medio"
+                    value={`${(getKPIValue('averageResponseTime') ?? summary?.averageResponseTime ?? 0) / 1000}s`}
+                    trend={getTrend('averageResponseTime')}
+                    periodLabel={periodLabel}
+                    icon={<Clock className="text-white drop-shadow-sm" size={24} aria-hidden="true" />}
+                    color="bg-gradient-to-br from-accent-orange to-warning-base"
+                  />
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <StatCard
+                    title="Alumnos Activos"
+                    value={`${activeStudentsCount}/${totalStudents}`}
+                    trend=""
+                    periodLabel="ultimos 7 dias"
+                    icon={<UserCheck className="text-white drop-shadow-sm" size={24} aria-hidden="true" />}
+                    color="bg-gradient-to-br from-brand-base to-accent-pink"
+                  />
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <StatCard
+                    title="Tasa Completado"
+                    value={`${100 - (summary?.abandonmentRate || 0)}%`}
+                    trend=""
+                    periodLabel="partidas completadas"
+                    icon={<CheckCircle2 className="text-white drop-shadow-sm" size={24} aria-hidden="true" />}
+                    color="bg-gradient-to-br from-success-dark to-success-base"
+                  />
+                </motion.div>
               </div>
             </motion.section>
 
@@ -265,21 +332,34 @@ export default function Dashboard() {
                 <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
                   <DifficultyHeatmap data={difficulties} />
                 </motion.div>
+                {heatmapData && (
+                  <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+                    <ActivityHeatmap data={heatmapData} />
+                  </motion.div>
+                )}
               </div>
 
               {/* Columna Lateral (1/3 de ancho) */}
               <aside className="space-y-6 lg:space-y-8">
                 <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
-                  <ClassroomOverview summary={summary} distribution={null} />
+                  <ClassroomOverview summary={summary} distribution={distributionData} />
                 </motion.div>
                 <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
-                  <AlertsPanel alerts={alerts} />
+                  <AlertsPanel alerts={backendAlerts} />
+                </motion.div>
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+                  <StudentsList students={studentsData?.students} />
                 </motion.div>
                 <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
                   <QuickLinks navigate={navigate} />
                 </motion.div>
               </aside>
             </motion.section>
+
+            {/* Actividad Reciente (timeline) */}
+            {studentsData?.students?.length > 0 && (
+              <RecentActivity students={studentsData.students} />
+            )}
           </div>
         </motion.main>
       )}
@@ -342,8 +422,9 @@ function Header({ timeRange, setTimeRange, reducedMotion = false }) {
           value={timeRange}
           onChange={(val) => setTimeRange(val)}
           options={[
-            { value: '7d', label: 'Últimos 7 días' },
-            { value: '30d', label: 'Últimos 30 días' },
+            { value: '7d', label: 'Ultimos 7 dias' },
+            { value: '30d', label: 'Ultimos 30 dias' },
+            { value: '90d', label: 'Ultimos 90 dias' },
           ]}
           className="w-48"
         />
@@ -372,8 +453,8 @@ const QUICK_LINKS = [
 function QuickLinks({ navigate }) {
   return (
     <div className="rounded-2xl bg-background-elevated/60 backdrop-blur-sm border border-border-default p-5">
-      <h3 className="text-lg font-bold text-text-primary mb-3 px-1 font-display">Accesos Rápidos</h3>
-      <nav className="space-y-1" aria-label="Accesos rápidos">
+      <h3 className="text-lg font-bold text-text-primary mb-3 px-1 font-display">Accesos Rapidos</h3>
+      <nav className="space-y-1" aria-label="Accesos rapidos">
         {QUICK_LINKS.map(({ label, route, icon: Icon }) => (
           <button
             key={route}
@@ -387,5 +468,65 @@ function QuickLinks({ navigate }) {
         ))}
       </nav>
     </div>
+  );
+}
+
+/**
+ * Timeline de actividad reciente — muestra las ultimas partidas de alumnos.
+ * Se deriva de los datos de students (ordenados por lastPlayedAt).
+ */
+function RecentActivity({ students }) {
+  const recentStudents = useMemo(() => {
+    if (!students?.length) return [];
+    return [...students]
+      .filter(s => s.lastPlayedAt)
+      .sort((a, b) => new Date(b.lastPlayedAt) - new Date(a.lastPlayedAt))
+      .slice(0, 6);
+  }, [students]);
+
+  if (recentStudents.length === 0) return null;
+
+  const getInitials = (name) => {
+    if (!name) return '?';
+    const parts = name.trim().split(/\s+/);
+    return parts.length === 1 ? parts[0][0].toUpperCase() : (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  };
+
+  const getRelativeTime = (dateStr) => {
+    const diffMs = Date.now() - new Date(dateStr).getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 60) return `Hace ${diffMins}m`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `Hace ${diffHours}h`;
+    return `Hace ${Math.floor(diffHours / 24)}d`;
+  };
+
+  return (
+    <section className="bg-background-elevated/40 backdrop-blur-sm rounded-2xl border border-border-subtle p-5">
+      <h3 className="text-lg font-bold text-text-primary font-display mb-4">Actividad Reciente</h3>
+      <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1 custom-scrollbar">
+        {recentStudents.map((student) => (
+          <div
+            key={student.studentId || student._id}
+            className="flex-shrink-0 flex items-center gap-3 bg-background-surface/40 rounded-xl px-4 py-3 min-w-[200px] border border-border-subtle/50"
+          >
+            <div className="size-8 rounded-full bg-gradient-to-br from-accent-indigo to-brand-base flex items-center justify-center text-xs font-bold text-white">
+              {getInitials(student.name)}
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-text-primary truncate">{student.name}</p>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-text-muted font-bold tabular-nums">
+                  {Math.round(student.averageScore || 0)} pts
+                </span>
+                <span className="text-[10px] text-text-disabled">
+                  {getRelativeTime(student.lastPlayedAt)}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -9,7 +9,7 @@ import { useRefetchOnFocus } from '../hooks/useRefetchOnFocus';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { useAuth } from '../context/AuthContext';
 import analyticsService from '../services/analytics';
-import { isAbortError } from '../services/api';
+import { isAbortError, contextsAPI, mechanicsAPI } from '../services/api';
 import { captureException } from '../lib/sentry';
 import { ROUTES } from '../constants/routes';
 import StatCard from '../components/dashboard/StatCard';
@@ -29,6 +29,32 @@ export default function Dashboard() {
   useDocumentTitle('Dashboard');
   const { shouldReduceMotion } = useReducedMotion();
   const [timeRange, setTimeRange] = useState('7d');
+  const [selectedContextId, setSelectedContextId] = useState('');
+  const [selectedMechanicId, setSelectedMechanicId] = useState('');
+  const [contextOptions, setContextOptions] = useState([]);
+  const [mechanicOptions, setMechanicOptions] = useState([]);
+
+  // Cargar opciones de contextos y mecanicas una sola vez
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      contextsAPI.getContexts().catch(() => ({ data: { data: [] } })),
+      mechanicsAPI.getMechanics().catch(() => ({ data: { data: [] } }))
+    ]).then(([ctxRes, mechRes]) => {
+      if (cancelled) return;
+      const contexts = ctxRes?.data?.data || [];
+      const mechanics = mechRes?.data?.data || [];
+      setContextOptions([
+        { value: '', label: 'Todos los contextos' },
+        ...contexts.map(c => ({ value: c._id, label: c.name }))
+      ]);
+      setMechanicOptions([
+        { value: '', label: 'Todas las mecanicas' },
+        ...mechanics.map(m => ({ value: m._id, label: m.displayName || m.name }))
+      ]);
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // Redirigir super_admin a su panel
   useEffect(() => {
@@ -49,8 +75,17 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const dataAbortRef = useRef(null);
+  // Cache: evita re-fetch si los datos tienen menos de 60s de antiguedad (ej. tab-focus)
+  const lastFetchRef = useRef({ at: 0, key: '' });
+  const CACHE_TTL_MS = 60_000;
 
-  const fetchData = useCallback(() => {
+  const fetchData = useCallback((forceRefresh = false) => {
+    const cacheKey = `${timeRange}:${selectedContextId}:${selectedMechanicId}`;
+    const now = Date.now();
+    if (!forceRefresh && lastFetchRef.current.key === cacheKey && now - lastFetchRef.current.at < CACHE_TTL_MS) {
+      return; // Datos frescos, no re-fetch
+    }
+
     dataAbortRef.current?.abort();
     const controller = new AbortController();
     dataAbortRef.current = controller;
@@ -65,7 +100,11 @@ export default function Dashboard() {
           analyticsService.getClassroomTrends(timeRange, { signal: controller.signal }),
           analyticsService.getClassroomComparison(timeRange, { signal: controller.signal }).catch(() => []),
           analyticsService.getClassroomDifficulties({ signal: controller.signal }).catch(() => []),
-          analyticsService.getClassroomStudents({ sort: 'score', order: 'desc' }, { signal: controller.signal }).catch(() => null),
+          analyticsService.getClassroomStudents({
+            sort: 'score', order: 'desc',
+            ...(selectedContextId && { contextId: selectedContextId }),
+            ...(selectedMechanicId && { mechanicId: selectedMechanicId })
+          }, { signal: controller.signal }).catch(() => null),
           analyticsService.getClassroomDistribution({}, { signal: controller.signal }).catch(() => null),
           analyticsService.getAlerts({ limit: 5 }, { signal: controller.signal }).catch(() => null),
           analyticsService.getClassroomHeatmap(timeRange, { signal: controller.signal }).catch(() => null)
@@ -80,6 +119,7 @@ export default function Dashboard() {
         setAlertsData(alerts);
         setHeatmapData(heatmap);
         setError(null);
+        lastFetchRef.current = { at: Date.now(), key: cacheKey };
       } catch (err) {
         if (isAbortError(err)) return;
         captureException(err);
@@ -92,7 +132,7 @@ export default function Dashboard() {
     };
 
     run();
-  }, [timeRange]);
+  }, [timeRange, selectedContextId, selectedMechanicId]);
 
   useEffect(() => {
     fetchData();
@@ -192,7 +232,17 @@ export default function Dashboard() {
           className="p-6 lg:p-8 max-w-7xl mx-auto space-y-8"
           aria-label="Panel principal del dashboard"
         >
-          <Header timeRange={timeRange} setTimeRange={setTimeRange} reducedMotion={shouldReduceMotion} />
+          <Header
+            timeRange={timeRange}
+            setTimeRange={setTimeRange}
+            selectedContextId={selectedContextId}
+            setSelectedContextId={setSelectedContextId}
+            selectedMechanicId={selectedMechanicId}
+            setSelectedMechanicId={setSelectedMechanicId}
+            contextOptions={contextOptions}
+            mechanicOptions={mechanicOptions}
+            reducedMotion={shouldReduceMotion}
+          />
 
           <div className="flex flex-col gap-8">
             {loading && summary ? (
@@ -367,7 +417,13 @@ export default function Dashboard() {
   );
 }
 
-function Header({ timeRange, setTimeRange, reducedMotion = false }) {
+function Header({
+  timeRange, setTimeRange,
+  selectedContextId, setSelectedContextId,
+  selectedMechanicId, setSelectedMechanicId,
+  contextOptions, mechanicOptions,
+  reducedMotion = false,
+}) {
   const navigate = useNavigate();
   const todayRaw = formatDate(new Date(), 'long');
   // Spanish dates should only capitalize the first letter (e.g. "Jueves, 19 de marzo de 2026")
@@ -417,17 +473,38 @@ function Header({ timeRange, setTimeRange, reducedMotion = false }) {
           </ButtonPremium>
         </div>
 
-        {/* Global Filter */}
-        <SelectPremium
-          value={timeRange}
-          onChange={(val) => setTimeRange(val)}
-          options={[
-            { value: '7d', label: 'Ultimos 7 dias' },
-            { value: '30d', label: 'Ultimos 30 dias' },
-            { value: '90d', label: 'Ultimos 90 dias' },
-          ]}
-          className="w-48"
-        />
+        {/* Filtros globales */}
+        <div className="flex items-center gap-2 flex-wrap">
+          {contextOptions.length > 1 && (
+            <SelectPremium
+              value={selectedContextId}
+              onChange={(val) => setSelectedContextId(val)}
+              options={contextOptions}
+              className="w-44"
+              aria-label="Filtrar por contexto tematico"
+            />
+          )}
+          {mechanicOptions.length > 1 && (
+            <SelectPremium
+              value={selectedMechanicId}
+              onChange={(val) => setSelectedMechanicId(val)}
+              options={mechanicOptions}
+              className="w-44"
+              aria-label="Filtrar por mecanica de juego"
+            />
+          )}
+          <SelectPremium
+            value={timeRange}
+            onChange={(val) => setTimeRange(val)}
+            options={[
+              { value: '7d', label: 'Ultimos 7 dias' },
+              { value: '30d', label: 'Ultimos 30 dias' },
+              { value: '90d', label: 'Ultimos 90 dias' },
+            ]}
+            className="w-44"
+            aria-label="Filtrar por rango de tiempo"
+          />
+        </div>
 
         <motion.time 
           dateTime={new Date().toISOString().split('T')[0]}

--- a/frontend/src/pages/InsightsReports.jsx
+++ b/frontend/src/pages/InsightsReports.jsx
@@ -1,0 +1,594 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend,
+} from 'recharts';
+import {
+  BarChart3,
+  Bell,
+  FileText,
+  TrendingUp,
+} from 'lucide-react';
+import { cn, DURATION, EASING, listContainerVariants, listItemVariants } from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useRefetchOnFocus } from '../hooks/useRefetchOnFocus';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import analyticsService from '../services/analytics';
+import { isAbortError } from '../services/api';
+import { captureException } from '../lib/sentry';
+import GlassCard from '../components/ui/GlassCard';
+import SelectPremium from '../components/ui/SelectPremium';
+import SkeletonShimmer, { SkeletonChart } from '../components/ui/SkeletonShimmer';
+import ErrorState from '../components/ui/ErrorState';
+import ContentEffectivenessMatrix from '../components/analytics/ContentEffectivenessMatrix';
+import AlertsHub from '../components/analytics/AlertsHub';
+import ReportGenerator from '../components/analytics/ReportGenerator';
+
+/**
+ * Definicion de tabs disponibles.
+ */
+const TABS = [
+  { id: 'effectiveness', label: 'Efectividad', icon: BarChart3 },
+  { id: 'alerts', label: 'Alertas', icon: Bell },
+  { id: 'reports', label: 'Informes', icon: FileText },
+];
+
+/**
+ * Opciones de rango temporal global.
+ */
+const TIME_RANGE_OPTIONS = [
+  { value: '30d', label: 'Ultimos 30 dias' },
+  { value: '90d', label: 'Ultimos 90 dias' },
+];
+
+/**
+ * Tooltip personalizado para el grafico de curvas de aprendizaje.
+ */
+function LearningCurveTooltip({ active, payload, label }) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="bg-background-elevated border border-border-default rounded-lg p-3 shadow-xl text-sm">
+      <p className="text-text-muted text-xs mb-2">Intento #{label}</p>
+      {payload.map((entry) => (
+        <p key={entry.dataKey} style={{ color: entry.color }} className="text-xs">
+          {entry.name}: <span className="font-bold tabular-nums">{Math.round(entry.value)}%</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Colores de la paleta para lineas del grafico de aprendizaje.
+ */
+const CURVE_COLORS = [
+  'var(--color-brand-base)',
+  'var(--color-accent-cyan)',
+  'var(--color-accent-pink)',
+  'var(--color-accent-orange)',
+  'var(--color-success-base)',
+  'var(--color-warning-base)',
+];
+
+/**
+ * Seccion de curvas de aprendizaje con Recharts AreaChart.
+ */
+function LearningCurvesSection({ data, loading }) {
+  const chartData = useMemo(() => {
+    if (!data?.curves && !data?.learningCurves && !Array.isArray(data)) return [];
+
+    const curves = data.curves || data.learningCurves || data;
+    if (!Array.isArray(curves) || curves.length === 0) return [];
+
+    // Buscar el maximo de intentos entre todas las curvas
+    let maxAttempts = 0;
+    for (const curve of curves) {
+      const points = curve.dataPoints || curve.points || [];
+      if (points.length > maxAttempts) maxAttempts = points.length;
+    }
+
+    if (maxAttempts === 0) return [];
+
+    // Construir datos planos para Recharts
+    const result = [];
+    for (let i = 0; i < maxAttempts; i++) {
+      const point = { attempt: i + 1 };
+      for (const curve of curves) {
+        const name = curve.name || curve.contextName || curve.mechanicName || 'Curva';
+        const points = curve.dataPoints || curve.points || [];
+        if (points[i]) {
+          point[name] = points[i].averageScore ?? points[i].score ?? null;
+        }
+      }
+      result.push(point);
+    }
+
+    return result;
+  }, [data]);
+
+  const curveNames = useMemo(() => {
+    if (!data?.curves && !data?.learningCurves && !Array.isArray(data)) return [];
+    const curves = data.curves || data.learningCurves || data;
+    if (!Array.isArray(curves)) return [];
+    return curves.map(c => c.name || c.contextName || c.mechanicName || 'Curva');
+  }, [data]);
+
+  if (loading) {
+    return <SkeletonChart height={280} />;
+  }
+
+  if (chartData.length === 0) {
+    return (
+      <GlassCard variant="default" padding="none" className="p-5">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-2 rounded-lg bg-brand-base/10">
+            <TrendingUp size={20} className="text-brand-base" aria-hidden="true" />
+          </div>
+          <h3 className="text-base font-bold text-text-primary font-display">
+            Curvas de Aprendizaje
+          </h3>
+        </div>
+        <div className="h-[200px] flex items-center justify-center">
+          <p className="text-sm text-text-muted text-center">
+            Se necesitan mas datos de partidas repetidas para generar las curvas de aprendizaje.
+          </p>
+        </div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard variant="default" padding="none" className="p-5">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="p-2 rounded-lg bg-brand-base/10">
+          <TrendingUp size={20} className="text-brand-base" aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="text-base font-bold text-text-primary font-display">
+            Curvas de Aprendizaje
+          </h3>
+          <p className="text-xs text-text-muted mt-0.5">
+            Mejora del rendimiento con la repeticion
+          </p>
+        </div>
+      </div>
+
+      <div className="h-[280px] w-full -ml-2">
+        <ResponsiveContainer width="100%" height="100%" minWidth={0}>
+          <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+            <defs>
+              {curveNames.map((name, idx) => (
+                <linearGradient key={name} id={`gradient-${idx}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={CURVE_COLORS[idx % CURVE_COLORS.length]} stopOpacity={0.3} />
+                  <stop offset="95%" stopColor={CURVE_COLORS[idx % CURVE_COLORS.length]} stopOpacity={0} />
+                </linearGradient>
+              ))}
+            </defs>
+            <CartesianGrid
+              stroke="var(--color-border-subtle)"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              dataKey="attempt"
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              label={{ value: 'Intento', position: 'insideBottom', offset: -5, fill: 'var(--color-text-muted)', fontSize: 11 }}
+            />
+            <YAxis
+              domain={[0, 100]}
+              tick={{ fill: 'var(--color-text-muted)', fontSize: 11 }}
+              tickLine={false}
+              axisLine={false}
+              width={35}
+              label={{ value: 'Puntuacion %', angle: -90, position: 'insideLeft', fill: 'var(--color-text-muted)', fontSize: 10 }}
+            />
+            <Tooltip content={<LearningCurveTooltip />} />
+            <Legend
+              wrapperStyle={{ fontSize: '11px', color: 'var(--color-text-muted)' }}
+            />
+            {curveNames.map((name, idx) => (
+              <Area
+                key={name}
+                type="monotone"
+                dataKey={name}
+                stroke={CURVE_COLORS[idx % CURVE_COLORS.length]}
+                fill={`url(#gradient-${idx})`}
+                strokeWidth={2}
+                dot={{ r: 3, strokeWidth: 0, fill: CURVE_COLORS[idx % CURVE_COLORS.length] }}
+                activeDot={{ r: 5, stroke: CURVE_COLORS[idx % CURVE_COLORS.length], strokeWidth: 2 }}
+                connectNulls
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </GlassCard>
+  );
+}
+
+/**
+ * Pagina Insights y Reportes con tabs: Efectividad, Alertas, Informes.
+ * Cada tab carga sus propios datos al activarse.
+ */
+export default function InsightsReports() {
+  useDocumentTitle('Insights y Reportes');
+  const { shouldReduceMotion } = useReducedMotion();
+
+  const [activeTab, setActiveTab] = useState('effectiveness');
+  const [timeRange, setTimeRange] = useState('30d');
+
+  // ──────── Effectiveness tab state ────────
+  const [effectivenessData, setEffectivenessData] = useState(null);
+  const [learningCurvesData, setLearningCurvesData] = useState(null);
+  const [effectivenessLoading, setEffectivenessLoading] = useState(false);
+  const [effectivenessError, setEffectivenessError] = useState(null);
+  const effectivenessAbortRef = useRef(null);
+
+  // ──────── Alerts tab state ────────
+  const [alertsData, setAlertsData] = useState(null);
+  const [alertsLoading, setAlertsLoading] = useState(false);
+  const [alertsError, setAlertsError] = useState(null);
+  const [alertsCount, setAlertsCount] = useState(0);
+  const alertsAbortRef = useRef(null);
+
+  // Track which tabs have been loaded at least once for this timeRange
+  const [loadedTabs, setLoadedTabs] = useState({});
+
+  // ──────── Fetch effectiveness data ────────
+  const fetchEffectiveness = useCallback(() => {
+    effectivenessAbortRef.current?.abort();
+    const controller = new AbortController();
+    effectivenessAbortRef.current = controller;
+
+    const run = async () => {
+      try {
+        setEffectivenessLoading(true);
+        setEffectivenessError(null);
+
+        const [contextData, mechanicData, curvesData] = await Promise.all([
+          analyticsService.getContentEffectiveness(
+            { timeRange, groupBy: 'context' },
+            { signal: controller.signal }
+          ),
+          analyticsService.getContentEffectiveness(
+            { timeRange, groupBy: 'mechanic' },
+            { signal: controller.signal }
+          ),
+          analyticsService.getLearningCurves(
+            { timeRange: '90d' },
+            { signal: controller.signal }
+          ),
+        ]);
+
+        // Merge context and mechanic data for the matrix
+        const contextItems = contextData?.items || contextData?.data || contextData || [];
+        const mechanicItems = mechanicData?.items || mechanicData?.data || mechanicData || [];
+        const mergedData = [
+          ...(Array.isArray(contextItems) ? contextItems : []),
+          ...(Array.isArray(mechanicItems) ? mechanicItems : []),
+        ];
+
+        setEffectivenessData(mergedData);
+        setLearningCurvesData(curvesData);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        captureException(err);
+        setEffectivenessError('No se pudieron cargar los datos de efectividad.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setEffectivenessLoading(false);
+        }
+      }
+    };
+
+    run();
+  }, [timeRange]);
+
+  // ──────── Fetch alerts data ────────
+  const fetchAlerts = useCallback(() => {
+    alertsAbortRef.current?.abort();
+    const controller = new AbortController();
+    alertsAbortRef.current = controller;
+
+    const run = async () => {
+      try {
+        setAlertsLoading(true);
+        setAlertsError(null);
+
+        const [alerts, summary] = await Promise.all([
+          analyticsService.getAlerts({}, { signal: controller.signal }),
+          analyticsService.getAlertsSummary({ signal: controller.signal }),
+        ]);
+
+        const alertList = alerts?.alerts || alerts || [];
+        setAlertsData(alertList);
+
+        const total = summary?.total ?? (
+          (summary?.critical || 0) + (summary?.warning || 0) + (summary?.info || 0)
+        );
+        setAlertsCount(Array.isArray(alertList) ? alertList.length : total || 0);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        captureException(err);
+        setAlertsError('No se pudieron cargar las alertas.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setAlertsLoading(false);
+        }
+      }
+    };
+
+    run();
+  }, []);
+
+  // ──────── Load data on tab change ────────
+  useEffect(() => {
+    const tabKey = `${activeTab}-${timeRange}`;
+    if (loadedTabs[tabKey]) return;
+
+    if (activeTab === 'effectiveness') {
+      fetchEffectiveness();
+      setLoadedTabs(prev => ({ ...prev, [tabKey]: true }));
+    } else if (activeTab === 'alerts') {
+      fetchAlerts();
+      setLoadedTabs(prev => ({ ...prev, [tabKey]: true }));
+    }
+    // 'reports' tab manages its own fetching via ReportGenerator
+  }, [activeTab, timeRange, loadedTabs, fetchEffectiveness, fetchAlerts]);
+
+  // Reload effectiveness when timeRange changes
+  useEffect(() => {
+    if (activeTab === 'effectiveness') {
+      setLoadedTabs(prev => {
+        const updated = { ...prev };
+        // Invalidate previous effectiveness entries
+        for (const key of Object.keys(updated)) {
+          if (key.startsWith('effectiveness-')) {
+            delete updated[key];
+          }
+        }
+        return updated;
+      });
+    }
+  }, [timeRange, activeTab]);
+
+  // Fetch alerts count for badge on mount
+  useEffect(() => {
+    const controller = new AbortController();
+    const fetchCount = async () => {
+      try {
+        const summary = await analyticsService.getAlertsSummary({ signal: controller.signal });
+        const total = summary?.total ?? (
+          (summary?.critical || 0) + (summary?.warning || 0) + (summary?.info || 0)
+        );
+        setAlertsCount(total || 0);
+      } catch (err) {
+        if (!isAbortError(err)) {
+          captureException(err);
+        }
+      }
+    };
+    fetchCount();
+    return () => controller.abort();
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      effectivenessAbortRef.current?.abort();
+      alertsAbortRef.current?.abort();
+    };
+  }, []);
+
+  // Refetch on focus
+  const currentFetchFn = useMemo(() => {
+    if (activeTab === 'effectiveness') return fetchEffectiveness;
+    if (activeTab === 'alerts') return fetchAlerts;
+    return null;
+  }, [activeTab, fetchEffectiveness, fetchAlerts]);
+
+  const currentLoading = activeTab === 'effectiveness' ? effectivenessLoading : alertsLoading;
+  const currentHasData = activeTab === 'effectiveness' ? Boolean(effectivenessData) : Boolean(alertsData);
+  const currentHasError = activeTab === 'effectiveness' ? Boolean(effectivenessError) : Boolean(alertsError);
+
+  useRefetchOnFocus({
+    refetch: currentFetchFn || (() => {}),
+    enabled: Boolean(currentFetchFn),
+    isLoading: currentLoading,
+    hasData: currentHasData,
+    hasError: currentHasError,
+  });
+
+  return (
+    <motion.main
+      initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: DURATION.entrance, ease: EASING.outExpo }}
+      className="p-6 lg:p-8 max-w-7xl mx-auto space-y-6"
+      aria-label="Insights y Reportes"
+    >
+      {/* Header */}
+      <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pt-14 lg:pt-0">
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold text-text-primary font-display">
+            Insights y Reportes
+          </h1>
+          <p className="text-text-muted mt-1 text-sm">
+            Analisis profundo de efectividad, alertas inteligentes e informes
+          </p>
+        </div>
+        <SelectPremium
+          value={timeRange}
+          onChange={setTimeRange}
+          options={TIME_RANGE_OPTIONS}
+          className="w-48"
+        />
+      </header>
+
+      {/* Tab navigation */}
+      <div className="flex items-center gap-1 border-b border-border-subtle" role="tablist" aria-label="Secciones de insights">
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          const TabIcon = tab.icon;
+          const showBadge = tab.id === 'alerts' && alertsCount > 0;
+
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`panel-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setActiveTab(tab.id)}
+              onKeyDown={(e) => {
+                const currentIndex = TABS.findIndex(t => t.id === tab.id);
+                if (e.key === 'ArrowRight') {
+                  e.preventDefault();
+                  const nextTab = TABS[(currentIndex + 1) % TABS.length];
+                  setActiveTab(nextTab.id);
+                  document.querySelector(`[aria-controls="panel-${nextTab.id}"]`)?.focus();
+                } else if (e.key === 'ArrowLeft') {
+                  e.preventDefault();
+                  const prevTab = TABS[(currentIndex - 1 + TABS.length) % TABS.length];
+                  setActiveTab(prevTab.id);
+                  document.querySelector(`[aria-controls="panel-${prevTab.id}"]`)?.focus();
+                }
+              }}
+              className={cn(
+                'relative flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors duration-200',
+                'focus-ring rounded-t-lg -mb-px',
+                isActive
+                  ? 'text-brand-base border-b-2 border-brand-base'
+                  : 'text-text-muted hover:text-text-secondary border-b-2 border-transparent'
+              )}
+            >
+              <TabIcon size={16} aria-hidden="true" />
+              <span>{tab.label}</span>
+              {showBadge && (
+                <span className={cn(
+                  'ml-1 px-1.5 py-0.5 text-[10px] font-bold rounded-full tabular-nums',
+                  isActive
+                    ? 'bg-brand-base/20 text-brand-base'
+                    : 'bg-error-base/20 text-error-base'
+                )}>
+                  {alertsCount}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tab content */}
+      <AnimatePresence mode="wait">
+        {activeTab === 'effectiveness' && (
+          <motion.div
+            key="effectiveness"
+            id="panel-effectiveness"
+            role="tabpanel"
+            aria-labelledby="tab-effectiveness"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+            transition={{ duration: DURATION.stateChange, ease: EASING.outQuart }}
+          >
+            <EffectivenessTabContent
+              effectivenessData={effectivenessData}
+              learningCurvesData={learningCurvesData}
+              loading={effectivenessLoading}
+              error={effectivenessError}
+              onRetry={fetchEffectiveness}
+              shouldReduceMotion={shouldReduceMotion}
+            />
+          </motion.div>
+        )}
+
+        {activeTab === 'alerts' && (
+          <motion.div
+            key="alerts"
+            id="panel-alerts"
+            role="tabpanel"
+            aria-labelledby="tab-alerts"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+            transition={{ duration: DURATION.stateChange, ease: EASING.outQuart }}
+          >
+            <AlertsTabContent
+              alerts={alertsData}
+              loading={alertsLoading}
+              error={alertsError}
+              onRetry={fetchAlerts}
+            />
+          </motion.div>
+        )}
+
+        {activeTab === 'reports' && (
+          <motion.div
+            key="reports"
+            id="panel-reports"
+            role="tabpanel"
+            aria-labelledby="tab-reports"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+            transition={{ duration: DURATION.stateChange, ease: EASING.outQuart }}
+          >
+            <ReportGenerator />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.main>
+  );
+}
+
+/**
+ * Contenido del tab de Efectividad.
+ */
+function EffectivenessTabContent({ effectivenessData, learningCurvesData, loading, error, onRetry, shouldReduceMotion }) {
+  if (error) {
+    return <ErrorState title="Error al cargar datos" message={error} onRetry={onRetry} />;
+  }
+
+  if (loading && !effectivenessData) {
+    return (
+      <div className="space-y-6">
+        <SkeletonShimmer className="h-[300px] rounded-2xl" />
+        <SkeletonChart height={280} />
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      variants={shouldReduceMotion ? {} : listContainerVariants(0.12)}
+      initial={shouldReduceMotion ? false : 'hidden'}
+      animate="visible"
+      className="space-y-6"
+    >
+      <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+        <ContentEffectivenessMatrix data={effectivenessData} />
+      </motion.div>
+      <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+        <LearningCurvesSection
+          data={learningCurvesData}
+          loading={loading}
+        />
+      </motion.div>
+    </motion.div>
+  );
+}
+
+/**
+ * Contenido del tab de Alertas.
+ */
+function AlertsTabContent({ alerts, loading, error, onRetry }) {
+  if (error) {
+    return <ErrorState title="Error al cargar alertas" message={error} onRetry={onRetry} />;
+  }
+
+  return <AlertsHub alerts={alerts || []} loading={loading} />;
+}

--- a/frontend/src/pages/StudentProfile.jsx
+++ b/frontend/src/pages/StudentProfile.jsx
@@ -1,0 +1,351 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { ArrowLeft, User } from 'lucide-react';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useRefetchOnFocus } from '../hooks/useRefetchOnFocus';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import { listContainerVariants, listItemVariants, crossfadeVariants } from '../lib/utils';
+import analyticsService from '../services/analytics';
+import { isAbortError } from '../services/api';
+import { captureException } from '../lib/sentry';
+import ErrorState from '../components/ui/ErrorState';
+import SkeletonShimmer, { SkeletonStatCard, SkeletonChart } from '../components/ui/SkeletonShimmer';
+import SelectPremium from '../components/ui/SelectPremium';
+import ButtonPremium from '../components/ui/ButtonPremium';
+import StudentKPICard from '../components/analytics/StudentKPICard';
+import TrajectoryChart from '../components/analytics/TrajectoryChart';
+import NarrativeCard from '../components/analytics/NarrativeCard';
+import PerformanceByDimension from '../components/analytics/PerformanceByDimension';
+import GameHistoryTable from '../components/analytics/GameHistoryTable';
+import StrengthsWeaknesses from '../components/analytics/StrengthsWeaknesses';
+import EngagementRadar from '../components/analytics/EngagementRadar';
+
+/**
+ * Tiers de rendimiento con labels y colores RAG
+ */
+const TIER_CONFIG = {
+  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base border-success-base/30' },
+  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80 border-success-base/20' },
+  average: { label: 'Promedio', className: 'bg-warning-base/15 text-warning-base border-warning-base/30' },
+  risk: { label: 'Necesita apoyo', className: 'bg-error-base/15 text-error-base border-error-base/30' },
+};
+
+const scoreToRAG = (score) => {
+  if (score >= 70) return 'green';
+  if (score >= 50) return 'amber';
+  return 'red';
+};
+
+const scoreToTier = (score) => {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'average';
+  return 'risk';
+};
+
+const getRelativeTime = (dateStr) => {
+  if (!dateStr) return 'Sin actividad';
+  const diffDays = Math.floor((new Date() - new Date(dateStr)) / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'Hoy';
+  if (diffDays === 1) return 'Ayer';
+  if (diffDays < 7) return `Hace ${diffDays} dias`;
+  if (diffDays < 30) return `Hace ${Math.floor(diffDays / 7)} semanas`;
+  return `Hace ${Math.floor(diffDays / 30)} meses`;
+};
+
+const getActivityColor = (dateStr) => {
+  if (!dateStr) return 'bg-text-muted';
+  const diffDays = Math.floor((new Date() - new Date(dateStr)) / (1000 * 60 * 60 * 24));
+  if (diffDays <= 3) return 'bg-success-base';
+  if (diffDays <= 7) return 'bg-warning-base';
+  return 'bg-error-base';
+};
+
+const getInitials = (name) => {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+};
+
+/**
+ * Pagina de perfil individual de un estudiante con BI avanzado.
+ * Pieza central del TFG: permite al profesor entender fortalezas,
+ * debilidades y evolucion de cada alumno.
+ */
+export default function StudentProfile() {
+  const { studentId } = useParams();
+  const navigate = useNavigate();
+  useDocumentTitle('Perfil de Estudiante');
+  const { shouldReduceMotion } = useReducedMotion();
+  const [timeRange, setTimeRange] = useState('30d');
+
+  const [summary, setSummary] = useState(null);
+  const [trajectory, setTrajectory] = useState(null);
+  const [engagement, setEngagement] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const abortRef = useRef(null);
+
+  const fetchData = useCallback(() => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const run = async () => {
+      try {
+        setLoading(true);
+
+        // Fetch principal: summary contiene datos basicos, partidas, rendimiento, comparativa
+        const summaryData = await analyticsService.getStudentSummary(
+          studentId, { timeRange }, { signal: controller.signal }
+        );
+        setSummary(summaryData);
+
+        // Fetches secundarios en paralelo (no bloqueantes si fallan)
+        const [trajectoryData, engagementData] = await Promise.all([
+          analyticsService.getStudentTrajectory(
+            studentId, { timeRange, granularity: 'daily' }, { signal: controller.signal }
+          ).catch(() => null),
+          analyticsService.getStudentEngagement(
+            studentId, { timeRange: '30d' }, { signal: controller.signal }
+          ).catch(() => null),
+        ]);
+
+        setTrajectory(trajectoryData);
+        setEngagement(engagementData);
+        setError(null);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        captureException(err);
+        setError('No se pudieron cargar los datos del estudiante.');
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    run();
+  }, [studentId, timeRange]);
+
+  useEffect(() => {
+    fetchData();
+    return () => abortRef.current?.abort();
+  }, [fetchData]);
+
+  useRefetchOnFocus({ refetch: fetchData, isLoading: loading, hasData: Boolean(summary), hasError: Boolean(error) });
+
+  const student = summary?.student;
+  const metrics = student?.studentMetrics || {};
+  const classComparison = summary?.classComparison || {};
+  const tier = scoreToTier(metrics.averageScore || 0);
+  const tierConfig = TIER_CONFIG[tier];
+
+  // Skeleton loading
+  if (loading && !summary) {
+    return (
+      <main className="p-6 lg:p-8 max-w-7xl mx-auto space-y-6">
+        <div className="flex items-center gap-4 pt-14 lg:pt-0">
+          <SkeletonShimmer className="h-14 w-14 rounded-full" />
+          <div className="space-y-2">
+            <SkeletonShimmer className="h-7 w-52 rounded-md" />
+            <SkeletonShimmer className="h-4 w-36 rounded-md" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
+          {[...Array(6)].map((_, i) => <SkeletonStatCard key={i} />)}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+          <SkeletonChart height={310} className="lg:col-span-3" />
+          <SkeletonShimmer className="h-[310px] rounded-2xl lg:col-span-2" />
+        </div>
+      </main>
+    );
+  }
+
+  if (error && !summary) {
+    return (
+      <main className="p-6 lg:p-8 max-w-7xl mx-auto">
+        <ErrorState title="Error al cargar perfil" message={error} onRetry={fetchData} />
+      </main>
+    );
+  }
+
+  if (!student) {
+    return (
+      <main className="p-6 lg:p-8 max-w-7xl mx-auto text-center py-20">
+        <User size={48} className="text-text-muted mx-auto mb-4" />
+        <h1 className="text-xl font-bold text-text-primary">Estudiante no encontrado</h1>
+        <p className="text-text-muted mt-2">No se encontraron datos para este estudiante.</p>
+        <ButtonPremium variant="secondary" className="mt-4" onClick={() => navigate(-1)}>Volver</ButtonPremium>
+      </main>
+    );
+  }
+
+  const accuracyRate = metrics.totalCorrectAnswers != null && (metrics.totalCorrectAnswers + metrics.totalErrors) > 0
+    ? Math.round((metrics.totalCorrectAnswers / (metrics.totalCorrectAnswers + metrics.totalErrors)) * 100)
+    : 0;
+
+  const completionRate = metrics.totalGamesPlayed > 0
+    ? Math.round(((metrics.totalGamesPlayed - (metrics.totalAbandonedGames || 0)) / metrics.totalGamesPlayed) * 100)
+    : 0;
+
+  return (
+    <motion.main
+      {...(shouldReduceMotion ? {} : crossfadeVariants)}
+      className="p-6 lg:p-8 max-w-7xl mx-auto space-y-6"
+    >
+      {/* ═══════ HEADER ═══════ */}
+      <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-14 lg:pt-0">
+        <div className="flex items-center gap-4">
+          <ButtonPremium variant="ghost" size="icon" onClick={() => navigate(-1)} aria-label="Volver">
+            <ArrowLeft size={20} />
+          </ButtonPremium>
+
+          <div className="size-14 rounded-full bg-gradient-to-br from-accent-indigo to-brand-base flex items-center justify-center text-xl font-bold text-white shadow-lg">
+            {student.avatar
+              ? <img src={student.avatar} alt="" className="size-full rounded-full object-cover" />
+              : <span>{getInitials(student.name)}</span>
+            }
+          </div>
+
+          <div>
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-2xl font-bold text-text-primary font-display">{student.name}</h1>
+              <span className={`text-xs font-semibold px-2.5 py-1 rounded-lg border ${tierConfig.className}`} aria-label={`Nivel de rendimiento: ${tierConfig.label}`}>
+                {tierConfig.label}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 mt-1">
+              {student.classroom && <span className="text-sm text-text-muted">Aula: {student.classroom}</span>}
+              <span className="flex items-center gap-1.5 text-sm text-text-muted">
+                <span className={`size-2 rounded-full ${getActivityColor(metrics.lastPlayedAt)}`} aria-hidden="true" />
+                {getRelativeTime(metrics.lastPlayedAt)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <SelectPremium
+          value={timeRange}
+          onChange={setTimeRange}
+          options={[
+            { value: '7d', label: 'Ultimos 7 dias' },
+            { value: '30d', label: 'Ultimos 30 dias' },
+            { value: '90d', label: 'Ultimos 90 dias' },
+          ]}
+          className="w-48"
+        />
+      </header>
+
+      {/* ═══════ KPIs — 6 cards con RAG y comparativa clase ═══════ */}
+      <motion.section
+        variants={listContainerVariants(0.06)}
+        initial={shouldReduceMotion ? false : "hidden"}
+        animate="visible"
+        aria-label="KPIs del estudiante"
+      >
+        <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3 lg:gap-4">
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Puntuacion Media"
+              value={Math.round(metrics.averageScore || 0)}
+              suffix="%"
+              ragStatus={scoreToRAG(metrics.averageScore || 0)}
+              comparison={classComparison.averageScore != null ? `vs clase: ${Math.round(classComparison.averageScore)}%` : null}
+              comparisonPositive={metrics.averageScore > (classComparison.averageScore || 0)}
+            />
+          </motion.div>
+
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Tasa de Acierto"
+              value={accuracyRate}
+              suffix="%"
+              ragStatus={scoreToRAG(accuracyRate)}
+              comparison={classComparison.accuracy != null ? `vs clase: ${Math.round(classComparison.accuracy)}%` : null}
+              comparisonPositive={accuracyRate > (classComparison.accuracy || 0)}
+            />
+          </motion.div>
+
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Tiempo Respuesta"
+              value={((metrics.averageResponseTime || 0) / 1000).toFixed(1)}
+              suffix="s"
+              ragStatus={metrics.averageResponseTime <= 4000 ? 'green' : metrics.averageResponseTime <= 8000 ? 'amber' : 'red'}
+              comparison={classComparison.responseTime != null ? `vs clase: ${(classComparison.responseTime / 1000).toFixed(1)}s` : null}
+              comparisonPositive={metrics.averageResponseTime < (classComparison.responseTime || Infinity)}
+            />
+          </motion.div>
+
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Engagement"
+              value={engagement?.engagementScore != null ? Math.round(engagement.engagementScore) : '—'}
+              ragStatus={engagement?.engagementScore >= 60 ? 'green' : engagement?.engagementScore >= 35 ? 'amber' : engagement ? 'red' : 'gray'}
+            />
+          </motion.div>
+
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Total Partidas"
+              value={metrics.totalGamesPlayed || 0}
+              ragStatus="gray"
+              comparison={`Mejor: ${metrics.bestScore || 0} pts`}
+            />
+          </motion.div>
+
+          <motion.div variants={shouldReduceMotion ? {} : listItemVariants}>
+            <StudentKPICard
+              label="Completado"
+              value={completionRate}
+              suffix="%"
+              ragStatus={completionRate >= 85 ? 'green' : completionRate >= 60 ? 'amber' : 'red'}
+              comparison={metrics.totalAbandonedGames > 0 ? `${metrics.totalAbandonedGames} abandonadas` : 'Sin abandonos'}
+            />
+          </motion.div>
+        </div>
+      </motion.section>
+
+      {/* ═══════ Trayectoria + Narrativa ═══════ */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+        <div className="lg:col-span-3">
+          <TrajectoryChart
+            trajectoryData={trajectory}
+            classComparison={summary?.classProgressComparison}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <NarrativeCard interpretation={trajectory?.interpretation || summary?.interpretation} />
+        </div>
+      </div>
+
+      {/* ═══════ Rendimiento por Contexto y por Mecanica ═══════ */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <PerformanceByDimension
+          title="Rendimiento por Contexto"
+          data={summary?.performanceByContext}
+          dimension="context"
+        />
+        <PerformanceByDimension
+          title="Rendimiento por Mecanica"
+          data={summary?.performanceByMechanic}
+          dimension="mechanic"
+        />
+      </div>
+
+      {/* ═══════ Engagement + Fortalezas/Debilidades ═══════ */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <EngagementRadar engagement={engagement} />
+        <StrengthsWeaknesses
+          performanceByContext={summary?.performanceByContext}
+          performanceByMechanic={summary?.performanceByMechanic}
+        />
+      </div>
+
+      {/* ═══════ Historial de Partidas ═══════ */}
+      <GameHistoryTable games={summary?.lastGames} />
+    </motion.main>
+  );
+}

--- a/frontend/src/pages/StudentProfile.jsx
+++ b/frontend/src/pages/StudentProfile.jsx
@@ -20,29 +20,7 @@ import PerformanceByDimension from '../components/analytics/PerformanceByDimensi
 import GameHistoryTable from '../components/analytics/GameHistoryTable';
 import StrengthsWeaknesses from '../components/analytics/StrengthsWeaknesses';
 import EngagementRadar from '../components/analytics/EngagementRadar';
-
-/**
- * Tiers de rendimiento con labels y colores RAG
- */
-const TIER_CONFIG = {
-  excellent: { label: 'Excelente', className: 'bg-success-base/15 text-success-base border-success-base/30' },
-  good: { label: 'Bueno', className: 'bg-success-base/10 text-success-base/80 border-success-base/20' },
-  average: { label: 'Promedio', className: 'bg-warning-base/15 text-warning-base border-warning-base/30' },
-  risk: { label: 'Necesita apoyo', className: 'bg-error-base/15 text-error-base border-error-base/30' },
-};
-
-const scoreToRAG = (score) => {
-  if (score >= 70) return 'green';
-  if (score >= 50) return 'amber';
-  return 'red';
-};
-
-const scoreToTier = (score) => {
-  if (score >= 90) return 'excellent';
-  if (score >= 70) return 'good';
-  if (score >= 50) return 'average';
-  return 'risk';
-};
+import { TIER_CONFIG, scoreToRAG, scoreToTier } from '../constants/analyticsThresholds';
 
 const getRelativeTime = (dateStr) => {
   if (!dateStr) return 'Sin actividad';

--- a/frontend/src/pages/StudentsAnalytics.jsx
+++ b/frontend/src/pages/StudentsAnalytics.jsx
@@ -1,0 +1,732 @@
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Users, Trophy, AlertTriangle, UserCheck, Download,
+  Search, ArrowUpDown, ArrowUp, ArrowDown, GraduationCap,
+} from 'lucide-react';
+import {
+  listContainerVariants, listItemVariants, crossfadeVariants,
+  exportToCSV,
+} from '../lib/utils';
+import { useDocumentTitle } from '../hooks/useDocumentTitle';
+import { useRefetchOnFocus } from '../hooks/useRefetchOnFocus';
+import { useReducedMotion } from '../hooks/useReducedMotion';
+import analyticsService from '../services/analytics';
+import { isAbortError } from '../services/api';
+import { captureException } from '../lib/sentry';
+import { ROUTES } from '../constants/routes';
+import GlassCard from '../components/ui/GlassCard';
+import ButtonPremium from '../components/ui/ButtonPremium';
+import SelectPremium from '../components/ui/SelectPremium';
+import ErrorState from '../components/ui/ErrorState';
+import DistributionChart from '../components/dashboard/DistributionChart';
+import SkeletonShimmer, { SkeletonStatCard, SkeletonChart } from '../components/ui/SkeletonShimmer';
+
+// ─── Helper functions ───────────────────────────────────────────────
+
+/**
+ * Obtiene las iniciales de un nombre (max 2 caracteres).
+ * @param {string} name
+ * @returns {string}
+ */
+function getInitials(name) {
+  if (!name) return '?';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+/**
+ * Devuelve label y className para un tier de rendimiento.
+ * @param {string} tier - risk | average | good | excellent
+ * @returns {{label: string, className: string}}
+ */
+function getTierBadge(tier) {
+  switch (tier) {
+    case 'excellent':
+      return { label: 'Excelente', className: 'bg-success-dark/15 text-success-base border-success-dark/25' };
+    case 'good':
+      return { label: 'Bueno', className: 'bg-info-dark/15 text-info-base border-info-dark/25' };
+    case 'average':
+      return { label: 'Promedio', className: 'bg-warning-dark/15 text-warning-base border-warning-dark/25' };
+    case 'risk':
+      return { label: 'En Riesgo', className: 'bg-error-dark/15 text-error-base border-error-dark/25' };
+    default:
+      return { label: 'Sin datos', className: 'bg-text-disabled/10 text-text-muted border-text-disabled/20' };
+  }
+}
+
+/**
+ * Devuelve la clase tailwind para el indicador de actividad reciente.
+ * @param {string} dateStr - Fecha ISO
+ * @returns {string} Clase de color tailwind
+ */
+function getActivityColor(dateStr) {
+  if (!dateStr) return 'bg-text-disabled';
+  const diff = (Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24);
+  if (diff < 3) return 'bg-success-base';
+  if (diff <= 7) return 'bg-warning-base';
+  return 'bg-error-base';
+}
+
+/**
+ * Genera un texto relativo a partir de una fecha.
+ * @param {string} dateStr - Fecha ISO
+ * @returns {string} Texto "Hace X dias"
+ */
+function getRelativeTime(dateStr) {
+  if (!dateStr) return 'Sin actividad';
+  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24));
+  if (diff === 0) return 'Hoy';
+  if (diff === 1) return 'Hace 1 dia';
+  return `Hace ${diff} dias`;
+}
+
+/**
+ * Formatea tiempo de respuesta en milisegundos a formato legible.
+ * @param {number} ms - Milisegundos
+ * @returns {string} Formato "X.Xs"
+ */
+function formatResponseTime(ms) {
+  if (ms == null || isNaN(ms)) return '-';
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ─── CSV column definitions ─────────────────────────────────────────
+
+const CSV_COLUMNS = [
+  { key: 'name', label: 'Nombre' },
+  { key: 'classroom', label: 'Aula' },
+  { key: 'totalGames', label: 'Partidas' },
+  { key: 'averageScore', label: 'Puntuacion' },
+  { key: 'accuracyRate', label: 'Tasa Acierto' },
+  { key: 'avgResponseTime', label: 'Tiempo Respuesta' },
+  { key: 'lastPlayedAt', label: 'Ultima Actividad' },
+  { key: 'tier', label: 'Nivel' },
+];
+
+// ─── Tier filter options ────────────────────────────────────────────
+
+const TIER_OPTIONS = [
+  { value: '', label: 'Todos' },
+  { value: 'excellent', label: 'Excelente' },
+  { value: 'good', label: 'Bueno' },
+  { value: 'average', label: 'Promedio' },
+  { value: 'risk', label: 'En Riesgo' },
+];
+
+// ─── Table column config ────────────────────────────────────────────
+
+const TABLE_COLUMNS = [
+  { key: 'name', label: 'Alumno', sortable: true },
+  { key: 'classroom', label: 'Aula', sortable: true },
+  { key: 'totalGames', label: 'Partidas', sortable: true },
+  { key: 'averageScore', label: 'Score', sortable: true },
+  { key: 'accuracyRate', label: 'Tasa Acierto', sortable: true },
+  { key: 'avgResponseTime', label: 'Tiempo Resp', sortable: true },
+  { key: 'lastPlayedAt', label: 'Ultima Actividad', sortable: true },
+  { key: 'tier', label: 'Nivel', sortable: true },
+];
+
+// ─── Main Component ─────────────────────────────────────────────────
+
+export default function StudentsAnalytics() {
+  const navigate = useNavigate();
+  useDocumentTitle('Mis Alumnos');
+  const { shouldReduceMotion } = useReducedMotion();
+
+  // Data state
+  const [students, setStudents] = useState(null);
+  const [summary, setSummary] = useState(null);
+  const [distribution, setDistribution] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const dataAbortRef = useRef(null);
+
+  // Search and filter state
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [tierFilter, setTierFilter] = useState('');
+
+  // Sort state
+  const [sortField, setSortField] = useState('averageScore');
+  const [sortOrder, setSortOrder] = useState('desc');
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Data fetching
+  const fetchData = useCallback(() => {
+    dataAbortRef.current?.abort();
+    const controller = new AbortController();
+    dataAbortRef.current = controller;
+
+    const run = async () => {
+      try {
+        setLoading(true);
+        const [studentsData, summaryData, distributionData] = await Promise.all([
+          analyticsService.getClassroomStudents(
+            { sort: 'score', order: 'desc' },
+            { signal: controller.signal }
+          ),
+          analyticsService.getClassroomSummary({ signal: controller.signal }),
+          analyticsService.getClassroomDistribution({}, { signal: controller.signal }),
+        ]);
+
+        setStudents(studentsData);
+        setSummary(summaryData);
+        setDistribution(distributionData);
+        setError(null);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        captureException(err);
+        setError('No se pudieron cargar los datos de los alumnos.');
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    return () => dataAbortRef.current?.abort();
+  }, [fetchData]);
+
+  useRefetchOnFocus({
+    refetch: fetchData,
+    isLoading: loading,
+    hasData: Boolean(students),
+    hasError: Boolean(error),
+  });
+
+  // Derive filtered and sorted students
+  const processedStudents = useMemo(() => {
+    if (!students?.students) return [];
+
+    let filtered = students.students;
+
+    // Apply search filter
+    if (debouncedSearch) {
+      const query = debouncedSearch.toLowerCase();
+      filtered = filtered.filter(s =>
+        s.name?.toLowerCase().includes(query)
+      );
+    }
+
+    // Apply tier filter
+    if (tierFilter) {
+      filtered = filtered.filter(s => s.tier === tierFilter);
+    }
+
+    // Apply sorting
+    const sorted = [...filtered].sort((a, b) => {
+      let aVal = a[sortField];
+      let bVal = b[sortField];
+
+      // Handle date comparison
+      if (sortField === 'lastPlayedAt') {
+        aVal = aVal ? new Date(aVal).getTime() : 0;
+        bVal = bVal ? new Date(bVal).getTime() : 0;
+      }
+
+      // Handle string comparison
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return sortOrder === 'asc'
+          ? aVal.localeCompare(bVal, 'es')
+          : bVal.localeCompare(aVal, 'es');
+      }
+
+      // Numeric comparison (nulls to bottom)
+      aVal = aVal ?? -Infinity;
+      bVal = bVal ?? -Infinity;
+      return sortOrder === 'asc' ? aVal - bVal : bVal - aVal;
+    });
+
+    return sorted;
+  }, [students, debouncedSearch, tierFilter, sortField, sortOrder]);
+
+  // Derived KPIs
+  const totalStudents = students?.students?.length ?? 0;
+  const classAverage = summary?.averageScore ?? 0;
+  const studentsInRisk = summary?.studentsInRisk ?? 0;
+
+  const activeStudentsCount = useMemo(() => {
+    if (!students?.students) return 0;
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    return students.students.filter(s => {
+      if (!s.lastPlayedAt) return false;
+      return new Date(s.lastPlayedAt) >= sevenDaysAgo;
+    }).length;
+  }, [students]);
+
+  // Sort handler
+  const handleSort = useCallback((field) => {
+    setSortField(prev => {
+      if (prev === field) {
+        setSortOrder(o => (o === 'asc' ? 'desc' : 'asc'));
+        return field;
+      }
+      setSortOrder('desc');
+      return field;
+    });
+  }, []);
+
+  // CSV Export
+  const handleExport = useCallback(() => {
+    if (!processedStudents.length) return;
+
+    const exportData = processedStudents.map(s => ({
+      name: s.name || '',
+      classroom: s.classroom || '',
+      totalGames: s.totalGames ?? 0,
+      averageScore: s.averageScore ?? 0,
+      accuracyRate: s.accuracyRate != null ? `${s.accuracyRate}%` : '-',
+      avgResponseTime: formatResponseTime(s.avgResponseTime),
+      lastPlayedAt: s.lastPlayedAt ? new Date(s.lastPlayedAt).toLocaleDateString('es-ES') : 'Sin actividad',
+      tier: getTierBadge(s.tier).label,
+    }));
+
+    const today = new Date().toISOString().split('T')[0];
+    exportToCSV(exportData, `alumnos_${today}`, CSV_COLUMNS);
+  }, [processedStudents]);
+
+  // ─── Skeleton state ─────────────────────────────────────────────
+  const skeletonContent = loading && !students;
+
+  return (
+    <AnimatePresence mode="wait">
+      {skeletonContent ? (
+        <motion.main
+          key="skeleton"
+          {...(shouldReduceMotion ? {} : crossfadeVariants)}
+          className="p-6 lg:p-8 max-w-7xl mx-auto space-y-8"
+        >
+          {/* Header skeleton */}
+          <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pt-14 lg:pt-0">
+            <div className="space-y-3">
+              <SkeletonShimmer className="h-8 w-56 rounded-lg" />
+              <SkeletonShimmer className="h-4 w-72 rounded-md" />
+            </div>
+            <SkeletonShimmer className="h-11 w-36 rounded-xl" />
+          </div>
+
+          {/* Summary KPIs skeleton */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6">
+            {[...Array(4)].map((_, i) => (
+              <SkeletonStatCard key={`stat-sk-${i}`} />
+            ))}
+          </div>
+
+          {/* Distribution chart skeleton */}
+          <SkeletonChart height={200} />
+
+          {/* Filters skeleton */}
+          <div className="flex flex-col sm:flex-row gap-4">
+            <SkeletonShimmer className="h-11 flex-1 rounded-xl" />
+            <SkeletonShimmer className="h-11 w-48 rounded-xl" />
+          </div>
+
+          {/* Table skeleton */}
+          <GlassCard padding="none">
+            <div className="p-4 space-y-3">
+              {[...Array(8)].map((_, i) => (
+                <SkeletonShimmer key={`row-sk-${i}`} className="h-14 w-full rounded-lg" />
+              ))}
+            </div>
+          </GlassCard>
+        </motion.main>
+      ) : (
+        <motion.main
+          key="content"
+          {...(shouldReduceMotion ? {} : crossfadeVariants)}
+          className="p-6 lg:p-8 max-w-7xl mx-auto space-y-8"
+          aria-label="Pagina de analisis de alumnos"
+        >
+          {/* ─── Header ─────────────────────────────────────────── */}
+          <motion.header
+            initial={shouldReduceMotion ? false : { opacity: 0, y: -20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col sm:flex-row sm:justify-between sm:items-end gap-4 pt-14 lg:pt-0"
+          >
+            <div>
+              <motion.h1
+                initial={shouldReduceMotion ? false : { opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: shouldReduceMotion ? 0 : 0.1 }}
+                className="text-2xl sm:text-3xl font-bold text-text-primary font-display"
+              >
+                Mis Alumnos
+              </motion.h1>
+              <motion.p
+                initial={shouldReduceMotion ? false : { opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: shouldReduceMotion ? 0 : 0.2 }}
+                className="text-text-muted font-medium mt-1"
+              >
+                Vista comparativa de rendimiento y actividad de tus estudiantes
+              </motion.p>
+            </div>
+
+            <ButtonPremium
+              variant="secondary"
+              size="sm"
+              icon={<Download size={16} />}
+              onClick={handleExport}
+              disabled={!processedStudents.length}
+            >
+              Exportar CSV
+            </ButtonPremium>
+          </motion.header>
+
+          {/* ─── Refreshing indicator ───────────────────────────── */}
+          {loading && students ? (
+            <div className="bg-background-elevated/50 border border-border-default text-text-muted px-4 py-2 rounded-xl text-sm font-medium animate-pulse">
+              Actualizando datos...
+            </div>
+          ) : null}
+
+          {/* ─── Error state ────────────────────────────────────── */}
+          {error ? (
+            <ErrorState
+              title="Error al cargar datos"
+              message={`${error} Pulsa Reintentar o recarga la pagina.`}
+              onRetry={fetchData}
+            />
+          ) : null}
+
+          {/* ─── Summary KPIs ───────────────────────────────────── */}
+          {!error && (
+            <motion.section
+              variants={listContainerVariants(0.08)}
+              initial={shouldReduceMotion ? false : 'hidden'}
+              animate="visible"
+              aria-labelledby="kpis-heading"
+            >
+              <h2 id="kpis-heading" className="sr-only">Indicadores clave</h2>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:gap-6" role="list">
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <GlassCard padding="sm">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center size-10 rounded-xl bg-gradient-to-br from-brand-base to-accent-indigo shadow-[0_2px_8px_var(--color-brand-glow)]">
+                        <Users size={20} className="text-white" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-text-muted truncate">Total Alumnos</p>
+                        <p className="text-xl font-bold text-text-primary">{totalStudents}</p>
+                      </div>
+                    </div>
+                  </GlassCard>
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <GlassCard padding="sm">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center size-10 rounded-xl bg-gradient-to-br from-success-base to-success-dark shadow-[0_2px_8px_var(--color-success-glow)]">
+                        <Trophy size={20} className="text-white" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-text-muted truncate">Promedio Clase</p>
+                        <p className="text-xl font-bold text-text-primary">{classAverage}%</p>
+                      </div>
+                    </div>
+                  </GlassCard>
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <GlassCard padding="sm">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center size-10 rounded-xl bg-gradient-to-br from-error-base to-error-dark shadow-[0_2px_8px_var(--color-error-glow)]">
+                        <AlertTriangle size={20} className="text-white" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-text-muted truncate">Alumnos en Riesgo</p>
+                        <p className="text-xl font-bold text-text-primary">{studentsInRisk}</p>
+                      </div>
+                    </div>
+                  </GlassCard>
+                </motion.div>
+
+                <motion.div variants={shouldReduceMotion ? {} : listItemVariants} role="listitem">
+                  <GlassCard padding="sm">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center size-10 rounded-xl bg-gradient-to-br from-brand-base to-accent-pink shadow-[0_2px_8px_var(--color-brand-glow)]">
+                        <UserCheck size={20} className="text-white" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-text-muted truncate">Alumnos Activos</p>
+                        <p className="text-xl font-bold text-text-primary">
+                          {activeStudentsCount}/{totalStudents}
+                        </p>
+                      </div>
+                    </div>
+                  </GlassCard>
+                </motion.div>
+              </div>
+            </motion.section>
+          )}
+
+          {/* ─── Distribution Chart ─────────────────────────────── */}
+          {!error && distribution?.length > 0 && (
+            <motion.section
+              initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: shouldReduceMotion ? 0 : 0.2 }}
+            >
+              <GlassCard>
+                <h3 className="text-lg font-bold text-text-primary font-display mb-4">
+                  Distribucion de Rendimiento
+                </h3>
+                <div className="h-48">
+                  <DistributionChart data={distribution} />
+                </div>
+              </GlassCard>
+            </motion.section>
+          )}
+
+          {/* ─── Filters ────────────────────────────────────────── */}
+          {!error && (
+            <motion.section
+              initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: shouldReduceMotion ? 0 : 0.25 }}
+              className="flex flex-col sm:flex-row gap-4"
+              aria-label="Filtros de busqueda"
+            >
+              {/* Search input */}
+              <div className="relative flex-1">
+                <Search
+                  size={18}
+                  className="absolute left-3.5 top-1/2 -translate-y-1/2 text-text-muted pointer-events-none"
+                  aria-hidden="true"
+                />
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Buscar alumno por nombre..."
+                  aria-label="Buscar alumno por nombre"
+                  className="w-full h-11 pl-10 pr-4 rounded-xl bg-background-elevated/80 backdrop-blur-sm border border-border-default text-text-primary placeholder:text-text-muted text-sm transition-colors duration-300 focus:outline-none focus:border-brand-base/50 focus:ring-2 focus:ring-brand-base/20 hover:border-border-strong"
+                />
+              </div>
+
+              {/* Tier filter */}
+              <SelectPremium
+                value={tierFilter}
+                onChange={setTierFilter}
+                options={TIER_OPTIONS}
+                placeholder="Filtrar por nivel"
+                className="w-full sm:w-52"
+              />
+            </motion.section>
+          )}
+
+          {/* ─── Students Table ──────────────────────────────────── */}
+          {!error && !loading && totalStudents === 0 && (
+            <EmptyState shouldReduceMotion={shouldReduceMotion} />
+          )}
+
+          {!error && processedStudents.length > 0 && (
+            <motion.section
+              initial={shouldReduceMotion ? false : { opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: shouldReduceMotion ? 0 : 0.3 }}
+              aria-label="Tabla de alumnos"
+            >
+              <GlassCard padding="none" className="overflow-hidden">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border-subtle">
+                        {TABLE_COLUMNS.map(col => (
+                          <th
+                            key={col.key}
+                            scope="col"
+                            className="px-4 py-3 text-left text-xs font-semibold text-text-muted uppercase tracking-wider whitespace-nowrap"
+                            aria-sort={col.sortable && sortField === col.key ? (sortOrder === 'asc' ? 'ascending' : 'descending') : undefined}
+                          >
+                            {col.sortable ? (
+                              <button
+                                type="button"
+                                onClick={() => handleSort(col.key)}
+                                className="inline-flex items-center gap-1.5 hover:text-text-primary transition-colors duration-150 group"
+                                aria-label={`Ordenar por ${col.label}`}
+                              >
+                                {col.label}
+                                <SortIcon field={col.key} sortField={sortField} sortOrder={sortOrder} />
+                              </button>
+                            ) : (
+                              col.label
+                            )}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <motion.tbody
+                      variants={shouldReduceMotion ? {} : listContainerVariants(0.04)}
+                      initial={shouldReduceMotion ? false : 'hidden'}
+                      animate="visible"
+                    >
+                      {processedStudents.map((student) => (
+                        <StudentRow
+                          key={student._id || student.studentId}
+                          student={student}
+                          navigate={navigate}
+                          shouldReduceMotion={shouldReduceMotion}
+                        />
+                      ))}
+                    </motion.tbody>
+                  </table>
+                </div>
+
+                {/* Result count footer */}
+                <div className="px-4 py-3 border-t border-border-subtle text-xs text-text-muted">
+                  Mostrando {processedStudents.length} de {totalStudents} alumnos
+                  {(debouncedSearch || tierFilter) ? ' (filtrado)' : ''}
+                </div>
+              </GlassCard>
+            </motion.section>
+          )}
+
+          {/* No results from filter */}
+          {!error && !loading && totalStudents > 0 && processedStudents.length === 0 && (
+            <GlassCard className="text-center py-12">
+              <Search size={40} className="mx-auto text-text-muted/40 mb-4" aria-hidden="true" />
+              <p className="text-text-primary font-semibold">Sin resultados</p>
+              <p className="text-text-muted text-sm mt-1">
+                Ningun alumno coincide con los filtros aplicados
+              </p>
+            </GlassCard>
+          )}
+        </motion.main>
+      )}
+    </AnimatePresence>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────
+
+function SortIcon({ field, sortField, sortOrder }) {
+  if (field !== sortField) {
+    return <ArrowUpDown size={14} className="text-text-muted/40 group-hover:text-text-muted transition-colors" aria-hidden="true" />;
+  }
+  return sortOrder === 'asc'
+    ? <ArrowUp size={14} className="text-brand-base" aria-hidden="true" />
+    : <ArrowDown size={14} className="text-brand-base" aria-hidden="true" />;
+}
+
+function StudentRow({ student, navigate, shouldReduceMotion }) {
+  const tier = getTierBadge(student.tier);
+  const studentId = student._id || student.studentId;
+
+  return (
+    <motion.tr
+      variants={shouldReduceMotion ? {} : listItemVariants}
+      onClick={() => navigate(ROUTES.STUDENT_PROFILE(studentId))}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          navigate(ROUTES.STUDENT_PROFILE(studentId));
+        }
+      }}
+      tabIndex={0}
+      role="row"
+      className="border-b border-border-subtle/50 last:border-b-0 hover:bg-background-surface/40 cursor-pointer transition-colors duration-150 focus:outline-none focus:bg-background-surface/40 focus:ring-1 focus:ring-brand-base/30 focus:ring-inset"
+    >
+      {/* Avatar + Name */}
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3 min-w-[180px]">
+          <div
+            className="flex items-center justify-center size-9 rounded-full bg-gradient-to-br from-brand-base/30 to-accent-indigo/30 text-text-primary text-xs font-bold shrink-0 border border-border-subtle"
+            aria-hidden="true"
+          >
+            {getInitials(student.name)}
+          </div>
+          <span className="font-medium text-text-primary truncate">{student.name}</span>
+        </div>
+      </td>
+
+      {/* Classroom */}
+      <td className="px-4 py-3 text-text-secondary whitespace-nowrap">
+        {student.classroom || '-'}
+      </td>
+
+      {/* Total games */}
+      <td className="px-4 py-3 text-text-secondary text-center whitespace-nowrap">
+        {student.totalGames ?? 0}
+      </td>
+
+      {/* Average score */}
+      <td className="px-4 py-3 font-semibold text-text-primary text-center whitespace-nowrap">
+        {student.averageScore ?? 0}%
+      </td>
+
+      {/* Accuracy rate */}
+      <td className="px-4 py-3 text-text-secondary text-center whitespace-nowrap">
+        {student.accuracyRate != null ? `${student.accuracyRate}%` : '-'}
+      </td>
+
+      {/* Response time */}
+      <td className="px-4 py-3 text-text-secondary text-center whitespace-nowrap">
+        {formatResponseTime(student.avgResponseTime)}
+      </td>
+
+      {/* Last activity */}
+      <td className="px-4 py-3 whitespace-nowrap">
+        <div className="flex items-center gap-2">
+          <span className={`inline-block size-2 rounded-full shrink-0 ${getActivityColor(student.lastPlayedAt)}`} aria-hidden="true" />
+          <span className="text-text-secondary text-xs">
+            {getRelativeTime(student.lastPlayedAt)}
+          </span>
+        </div>
+      </td>
+
+      {/* Tier badge */}
+      <td className="px-4 py-3 whitespace-nowrap">
+        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wider border ${tier.className}`}>
+          {tier.label}
+        </span>
+      </td>
+    </motion.tr>
+  );
+}
+
+function EmptyState({ shouldReduceMotion }) {
+  return (
+    <GlassCard className="text-center py-16">
+      <motion.div
+        initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        className="mx-auto mb-6 flex size-20 items-center justify-center rounded-2xl bg-brand-base/10 text-brand-base"
+      >
+        <GraduationCap size={40} aria-hidden="true" />
+      </motion.div>
+      <motion.p
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1 }}
+        className="text-text-primary text-lg font-semibold"
+      >
+        Aun no tienes alumnos registrados
+      </motion.p>
+      <motion.p
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.15 }}
+        className="text-text-muted mt-2 max-w-md mx-auto"
+      >
+        Cuando tus alumnos jueguen sus primeras partidas, aqui podras ver su rendimiento y progreso.
+      </motion.p>
+    </GlassCard>
+  );
+}

--- a/frontend/src/pages/__tests__/Dashboard.analytics.test.jsx
+++ b/frontend/src/pages/__tests__/Dashboard.analytics.test.jsx
@@ -1,0 +1,383 @@
+/**
+ * @fileoverview Tests de integracion para la pagina Dashboard.
+ * Verifica la carga de datos de analytics, renderizado de KPIs,
+ * manejo de errores y comportamiento segun rol de usuario.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../Dashboard';
+
+// ── Mocks de navegacion ──
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// ── Mocks de hooks ──
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({ user: { _id: 'teacher-1', role: 'teacher' }, isSuperAdmin: false })
+}));
+vi.mock('../../hooks/useDocumentTitle', () => ({ useDocumentTitle: () => {} }));
+vi.mock('../../hooks/useReducedMotion', () => ({ useReducedMotion: () => ({ shouldReduceMotion: true }) }));
+vi.mock('../../hooks/useRefetchOnFocus', () => ({ useRefetchOnFocus: () => {} }));
+vi.mock('../../lib/sentry', () => ({ captureException: vi.fn() }));
+
+// ── Mock framer-motion ──
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_, tag) => {
+      const Component = (props) => {
+        const { children, initial, animate, exit, variants, transition, whileHover, whileTap, layout, ...rest } = props;
+        const domProps = {};
+        for (const [key, val] of Object.entries(rest)) {
+          if (typeof val !== 'object' || key === 'className' || key === 'style' || key.startsWith('data-') || key.startsWith('aria-') || key === 'role' || key === 'id' || key === 'onClick' || key === 'dateTime') {
+            domProps[key] = val;
+          }
+        }
+        const Tag = typeof tag === 'string' ? tag : 'div';
+        return <Tag {...domProps}>{children}</Tag>;
+      };
+      Component.displayName = `motion.${String(tag)}`;
+      return Component;
+    }
+  }),
+  AnimatePresence: ({ children }) => <>{children}</>,
+  animate: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+// ── Mock analytics service (vi.hoisted para que este disponible antes de vi.mock) ──
+const mockAnalyticsService = vi.hoisted(() => ({
+  getClassroomSummary: vi.fn(),
+  getClassroomTrends: vi.fn(),
+  getClassroomComparison: vi.fn(),
+  getClassroomDifficulties: vi.fn(),
+  getClassroomStudents: vi.fn(),
+  getClassroomDistribution: vi.fn(),
+  getClassroomHeatmap: vi.fn(),
+  getAlerts: vi.fn(),
+  getAlertsSummary: vi.fn(),
+}));
+
+vi.mock('../../services/analytics', () => ({
+  default: mockAnalyticsService
+}));
+
+vi.mock('../../services/api', () => ({
+  isAbortError: (err) => err?.name === 'AbortError',
+  contextsAPI: { getContexts: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+  mechanicsAPI: { getMechanics: vi.fn().mockResolvedValue({ data: { data: [] } }) },
+}));
+
+// ── Mock sub-componentes pesados como stubs simples ──
+vi.mock('../../components/dashboard/StudentProgressChart', () => ({ default: () => <div data-testid="progress-chart">Chart</div> }));
+vi.mock('../../components/dashboard/DifficultyHeatmap', () => ({ default: () => <div data-testid="difficulty-heatmap">Heatmap</div> }));
+vi.mock('../../components/analytics/ActivityHeatmap', () => ({ default: () => <div data-testid="activity-heatmap">Activity</div> }));
+vi.mock('../../components/dashboard/DistributionChart', () => ({ default: () => <div data-testid="distribution-chart">Distribution</div> }));
+vi.mock('../../components/dashboard/ChartSection', () => ({ default: ({ children, title }) => <div data-testid="chart-section"><h3>{title}</h3>{children}</div> }));
+vi.mock('../../components/ui/GlassCard', () => ({ default: ({ children, className }) => <div className={className}>{children}</div> }));
+
+// ── Datos mock ──
+const MOCK_SUMMARY = {
+  studentsInRisk: 2,
+  averageScore: 65,
+  gamesToday: 12,
+  totalGames: 150,
+  averageAccuracy: 72,
+  averageResponseTime: 3500,
+  abandonmentRate: 15,
+};
+
+const MOCK_TRENDS = {
+  kpis: [
+    { name: 'studentsInRisk', current: 2, previous: 3, changePercent: -33 },
+    { name: 'averageScore', current: 65, previous: 60, changePercent: 8 },
+    { name: 'gamesToday', current: 12, previous: 8, changePercent: 50 },
+    { name: 'totalGames', current: 150, previous: 120, changePercent: 25 },
+    { name: 'averageAccuracy', current: 72, previous: 68, changePercent: 6 },
+    { name: 'averageResponseTime', current: 3500, previous: 4000, changePercent: -13 },
+  ]
+};
+
+const MOCK_STUDENTS = {
+  students: [
+    { _id: 's1', name: 'Maria', averageScore: 85, totalGamesPlayed: 20, lastPlayedAt: new Date().toISOString(), profile: { classroom: 'A1' } },
+    { _id: 's2', name: 'Carlos', averageScore: 45, totalGamesPlayed: 10, lastPlayedAt: null, profile: { classroom: 'A1' } },
+  ],
+  total: 2,
+};
+
+const MOCK_DISTRIBUTION = [
+  { range: 'risk', count: 2, percentage: 20 },
+  { range: 'average', count: 3, percentage: 30 },
+  { range: 'good', count: 3, percentage: 30 },
+  { range: 'excellent', count: 2, percentage: 20 },
+];
+
+const MOCK_ALERTS = {
+  alerts: [
+    { _id: 'a1', type: 'declining_performance', severity: 'warning', message: 'Carlos ha bajado su rendimiento' },
+  ],
+};
+
+const MOCK_HEATMAP = {
+  data: [[0, 1, 2], [3, 4, 5]],
+  days: ['Lunes', 'Martes'],
+  hours: ['9:00', '10:00', '11:00'],
+};
+
+// ── Helper de renderizado ──
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+}
+
+// ──────────────── Suite principal ────────────────
+describe('Dashboard — integracion analytics', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Configurar todos los mocks para resolver con datos de test
+    mockAnalyticsService.getClassroomSummary.mockResolvedValue(MOCK_SUMMARY);
+    mockAnalyticsService.getClassroomTrends.mockResolvedValue(MOCK_TRENDS);
+    mockAnalyticsService.getClassroomComparison.mockResolvedValue([]);
+    mockAnalyticsService.getClassroomDifficulties.mockResolvedValue([]);
+    mockAnalyticsService.getClassroomStudents.mockResolvedValue(MOCK_STUDENTS);
+    mockAnalyticsService.getClassroomDistribution.mockResolvedValue(MOCK_DISTRIBUTION);
+    mockAnalyticsService.getAlerts.mockResolvedValue(MOCK_ALERTS);
+    mockAnalyticsService.getClassroomHeatmap.mockResolvedValue(MOCK_HEATMAP);
+  });
+
+  it('muestra skeleton mientras carga datos', () => {
+    // Dejar las promesas pendientes para que loading=true se mantenga
+    mockAnalyticsService.getClassroomSummary.mockReturnValue(new Promise(() => {}));
+    mockAnalyticsService.getClassroomTrends.mockReturnValue(new Promise(() => {}));
+
+    renderDashboard();
+
+    // El skeleton usa SkeletonStatCard que renderiza dentro del grid
+    // Verificar que NO se renderiza el contenido real mientras carga
+    expect(screen.queryByText('Alumnos en Riesgo')).not.toBeInTheDocument();
+    expect(screen.queryByText('Puntuación Media')).not.toBeInTheDocument();
+  });
+
+  it('muestra los StatCards con datos del summary', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Puntuación Media')).toBeInTheDocument();
+    expect(screen.getByText('Partidas Hoy')).toBeInTheDocument();
+    expect(screen.getByText('Partidas Totales')).toBeInTheDocument();
+  });
+
+  it('muestra KPIs secundarios con datos del summary', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Tasa de Acierto')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Tiempo Medio')).toBeInTheDocument();
+    expect(screen.getByText('Alumnos Activos')).toBeInTheDocument();
+    expect(screen.getByText('Tasa Completado')).toBeInTheDocument();
+  });
+
+  it('muestra el titulo de bienvenida', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      // Hay dos spans: uno aria-hidden con emoji y otro sr-only sin emoji
+      const matches = screen.getAllByText(/Bienvenido de nuevo/);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('muestra el subtitulo descriptivo del dashboard', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Resumen de actividad y análisis de rendimiento')).toBeInTheDocument();
+    });
+  });
+
+  it('llama a los servicios de analytics al montar', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(mockAnalyticsService.getClassroomSummary).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockAnalyticsService.getClassroomTrends).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getClassroomComparison).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getClassroomDifficulties).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getClassroomStudents).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getClassroomDistribution).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getAlerts).toHaveBeenCalledTimes(1);
+    expect(mockAnalyticsService.getClassroomHeatmap).toHaveBeenCalledTimes(1);
+  });
+
+  it('muestra error cuando el servicio principal falla', async () => {
+    mockAnalyticsService.getClassroomSummary.mockRejectedValue(new Error('Network error'));
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Error al cargar datos')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/No se pudieron cargar los datos del dashboard/)).toBeInTheDocument();
+  });
+
+  it('renderiza el selector de rango de tiempo', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    // El SelectPremium de tiempo siempre se renderiza con aria-label
+    expect(screen.getByLabelText('Filtrar por rango de tiempo')).toBeInTheDocument();
+  });
+
+  it('muestra la lista de estudiantes cuando hay datos', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    // El componente StudentsList recibe los datos de estudiantes
+    // y los renderiza — verificamos que el componente de progreso esta en el DOM
+    expect(screen.getByTestId('progress-chart')).toBeInTheDocument();
+  });
+
+  it('renderiza accesos rapidos', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Accesos Rapidos')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Ver todas las sesiones')).toBeInTheDocument();
+    expect(screen.getByText('Crear nueva sesión')).toBeInTheDocument();
+    expect(screen.getByText('Ver mazos de cartas')).toBeInTheDocument();
+  });
+
+  it('muestra actividad reciente cuando hay estudiantes con partidas', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Actividad Reciente')).toBeInTheDocument();
+    });
+
+    // Maria tiene lastPlayedAt, aparece en StudentsList y en RecentActivity
+    const mariaElements = screen.getAllByText('Maria');
+    expect(mariaElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('no muestra actividad reciente cuando ningun estudiante tiene partidas', async () => {
+    mockAnalyticsService.getClassroomStudents.mockResolvedValue({
+      students: [
+        { _id: 's1', name: 'Ana', averageScore: 50, lastPlayedAt: null },
+      ],
+      total: 1,
+    });
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Actividad Reciente')).not.toBeInTheDocument();
+  });
+
+  it('maneja el caso de datos parciales sin crash', async () => {
+    // Servicios secundarios fallan pero los principales funcionan
+    mockAnalyticsService.getClassroomStudents.mockRejectedValue(new Error('students fail'));
+    mockAnalyticsService.getClassroomDistribution.mockRejectedValue(new Error('distribution fail'));
+    mockAnalyticsService.getAlerts.mockRejectedValue(new Error('alerts fail'));
+    mockAnalyticsService.getClassroomHeatmap.mockRejectedValue(new Error('heatmap fail'));
+
+    renderDashboard();
+
+    // Los KPIs principales deben seguir visibles
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Puntuación Media')).toBeInTheDocument();
+    expect(screen.getByText('Partidas Hoy')).toBeInTheDocument();
+    // No debe haber mensaje de error si solo fallan los secundarios
+    expect(screen.queryByText('Error al cargar datos')).not.toBeInTheDocument();
+  });
+
+  it('renderiza los graficos stub correctamente', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('progress-chart')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('difficulty-heatmap')).toBeInTheDocument();
+  });
+
+  it('renderiza el heatmap de actividad cuando hay datos', async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument();
+    });
+  });
+
+  it('no renderiza el heatmap de actividad cuando no hay datos', async () => {
+    mockAnalyticsService.getClassroomHeatmap.mockResolvedValue(null);
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alumnos en Riesgo')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('activity-heatmap')).not.toBeInTheDocument();
+  });
+});
+
+// ──────────────── Suite super_admin ────────────────
+describe('Dashboard — redireccion super_admin', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('no renderiza dashboard si es super_admin — redirige a admin', async () => {
+    // Sobreescribir el mock de AuthContext para este test
+    const authModule = await import('../../context/AuthContext');
+    vi.spyOn(authModule, 'useAuth').mockReturnValue({
+      user: { _id: 'admin-1', role: 'super_admin' },
+      isSuperAdmin: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/admin/approvals', { replace: true });
+    });
+  });
+});

--- a/frontend/src/services/__tests__/analytics.test.js
+++ b/frontend/src/services/__tests__/analytics.test.js
@@ -1,0 +1,339 @@
+/**
+ * @fileoverview Tests unitarios para el servicio de analytics.
+ *
+ * Verifica que cada metodo del servicio invoca el endpoint correcto
+ * con los parametros esperados y devuelve los datos extraidos de la
+ * respuesta de la API.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted garantiza que mockGet existe antes del hoisting de vi.mock
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn().mockResolvedValue({ data: { success: true, data: {} } }),
+}));
+
+// Mock del modulo api
+vi.mock('../api', () => ({
+  default: { get: mockGet },
+  extractData: (response) => response?.data?.data ?? response?.data,
+  isAbortError: () => false,
+}));
+
+import analyticsService from '../analytics';
+
+describe('analyticsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ──────────────── Classroom Analytics ────────────────
+
+  describe('Classroom Analytics', () => {
+    it('getClassroomSummary llama GET /analytics/classroom/summary', async () => {
+      await analyticsService.getClassroomSummary();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/summary', {});
+    });
+
+    it('getClassroomComparison llama GET /analytics/classroom/comparison con timeRange', async () => {
+      await analyticsService.getClassroomComparison('30d');
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/comparison', {
+        params: { timeRange: '30d' },
+      });
+    });
+
+    it('getClassroomComparison usa timeRange por defecto 7d', async () => {
+      await analyticsService.getClassroomComparison();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/comparison', {
+        params: { timeRange: '7d' },
+      });
+    });
+
+    it('getClassroomTrends llama GET /analytics/classroom/trends con timeRange', async () => {
+      await analyticsService.getClassroomTrends('30d');
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/trends', {
+        params: { timeRange: '30d' },
+      });
+    });
+
+    it('getClassroomTrends usa timeRange por defecto 7d', async () => {
+      await analyticsService.getClassroomTrends();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/trends', {
+        params: { timeRange: '7d' },
+      });
+    });
+
+    it('getClassroomDifficulties llama GET /analytics/classroom/difficulties', async () => {
+      await analyticsService.getClassroomDifficulties();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/difficulties', {});
+    });
+
+    it('getClassroomStudents llama GET /analytics/classroom/students con params', async () => {
+      const params = { sort: 'name', order: 'asc', tier: 'excellent' };
+      await analyticsService.getClassroomStudents(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/students', {
+        params,
+      });
+    });
+
+    it('getClassroomDistribution llama GET /analytics/classroom/distribution con params', async () => {
+      const params = { timeRange: '30d' };
+      await analyticsService.getClassroomDistribution(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/distribution', {
+        params,
+      });
+    });
+
+    it('getClassroomHeatmap llama GET /analytics/classroom/heatmap con timeRange', async () => {
+      await analyticsService.getClassroomHeatmap('7d');
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/heatmap', {
+        params: { timeRange: '7d' },
+      });
+    });
+
+    it('getClassroomHeatmap usa timeRange por defecto 30d', async () => {
+      await analyticsService.getClassroomHeatmap();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/heatmap', {
+        params: { timeRange: '30d' },
+      });
+    });
+
+    it('getClassroomRankings llama GET /analytics/classroom/rankings con timeRange y limit', async () => {
+      await analyticsService.getClassroomRankings('7d', 5);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/rankings', {
+        params: { timeRange: '7d', limit: 5 },
+      });
+    });
+
+    it('getClassroomRankings usa valores por defecto (30d, 10)', async () => {
+      await analyticsService.getClassroomRankings();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/rankings', {
+        params: { timeRange: '30d', limit: 10 },
+      });
+    });
+
+    it('getClassroomEngagement llama GET /analytics/classroom/engagement con params', async () => {
+      const params = { timeRange: '30d', sort: 'score', order: 'desc' };
+      await analyticsService.getClassroomEngagement(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/engagement', {
+        params,
+      });
+    });
+
+    it('getClassroomFatigue llama GET /analytics/classroom/fatigue con timeRange', async () => {
+      await analyticsService.getClassroomFatigue('7d');
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/fatigue', {
+        params: { timeRange: '7d' },
+      });
+    });
+
+    it('getClassroomFatigue usa timeRange por defecto 30d', async () => {
+      await analyticsService.getClassroomFatigue();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/fatigue', {
+        params: { timeRange: '30d' },
+      });
+    });
+  });
+
+  // ──────────────── Content Effectiveness ────────────────
+
+  describe('Content Effectiveness', () => {
+    it('getContentEffectiveness llama GET /analytics/classroom/content-effectiveness con params', async () => {
+      const params = { timeRange: '30d', groupBy: 'context' };
+      await analyticsService.getContentEffectiveness(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/content-effectiveness', {
+        params,
+      });
+    });
+
+    it('getCardDifficulty llama GET /analytics/classroom/card-difficulty con params', async () => {
+      const params = { timeRange: '30d', contextId: 'ctx-1', threshold: 50 };
+      await analyticsService.getCardDifficulty(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/card-difficulty', {
+        params,
+      });
+    });
+
+    it('getLearningCurves llama GET /analytics/classroom/learning-curves con params', async () => {
+      const params = { timeRange: '90d', contextId: 'ctx-1', mechanicId: 'mech-1' };
+      await analyticsService.getLearningCurves(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/learning-curves', {
+        params,
+      });
+    });
+
+    it('getCardAnalysis llama GET /analytics/classroom/card-analysis con params', async () => {
+      const params = { timeRange: '30d', contextId: 'ctx-1', limit: 20 };
+      await analyticsService.getCardAnalysis(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/classroom/card-analysis', {
+        params,
+      });
+    });
+  });
+
+  // ──────────────── Student Analytics ────────────────
+
+  describe('Student Analytics', () => {
+    const studentId = 'student-123';
+
+    it('getStudentDifficulties llama GET /analytics/student/:id/difficulties', async () => {
+      await analyticsService.getStudentDifficulties(studentId);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/difficulties`,
+        {}
+      );
+    });
+
+    it('getStudentProgress llama GET /analytics/student/:id/progress con timeRange', async () => {
+      await analyticsService.getStudentProgress(studentId, '7d');
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/progress`,
+        { params: { timeRange: '7d' } }
+      );
+    });
+
+    it('getStudentSummary llama GET /analytics/student/:id/summary con params', async () => {
+      const params = { timeRange: '30d' };
+      await analyticsService.getStudentSummary(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/summary`,
+        { params }
+      );
+    });
+
+    it('getStudentTrajectory llama GET /analytics/student/:id/trajectory con params', async () => {
+      const params = { timeRange: '90d', granularity: 'weekly' };
+      await analyticsService.getStudentTrajectory(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/trajectory`,
+        { params }
+      );
+    });
+
+    it('getStudentVelocity llama GET /analytics/student/:id/velocity con params', async () => {
+      const params = { timeRange: '30d', windowDays: 7 };
+      await analyticsService.getStudentVelocity(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/velocity`,
+        { params }
+      );
+    });
+
+    it('getStudentPlateaus llama GET /analytics/student/:id/plateaus con params', async () => {
+      const params = { timeRange: '30d', minDays: 5 };
+      await analyticsService.getStudentPlateaus(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/plateaus`,
+        { params }
+      );
+    });
+
+    it('getStudentEvolution llama GET /analytics/student/:id/evolution con params', async () => {
+      const params = { timeRange: '30d', groupBy: 'mechanic' };
+      await analyticsService.getStudentEvolution(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/evolution`,
+        { params }
+      );
+    });
+
+    it('getStudentStruggles llama GET /analytics/student/:id/struggles con params', async () => {
+      const params = { timeRange: '30d', minConsecutiveErrors: 3 };
+      await analyticsService.getStudentStruggles(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/struggles`,
+        { params }
+      );
+    });
+
+    it('getStudentEngagement llama GET /analytics/student/:id/engagement con params', async () => {
+      const params = { timeRange: '90d' };
+      await analyticsService.getStudentEngagement(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/engagement`,
+        { params }
+      );
+    });
+
+    it('getStudentPlayPatterns llama GET /analytics/student/:id/play-patterns con params', async () => {
+      const params = { timeRange: '30d' };
+      await analyticsService.getStudentPlayPatterns(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/student/${studentId}/play-patterns`,
+        { params }
+      );
+    });
+  });
+
+  // ──────────────── Gameplay Analysis ────────────────
+
+  describe('Gameplay Analysis', () => {
+    it('getGameplayRounds llama GET /analytics/gameplay/:id/rounds', async () => {
+      const gameplayId = 'gameplay-456';
+      await analyticsService.getGameplayRounds(gameplayId);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/gameplay/${gameplayId}/rounds`,
+        {}
+      );
+    });
+  });
+
+  // ──────────────── Alerts ────────────────
+
+  describe('Alerts', () => {
+    it('getAlerts llama GET /analytics/alerts con params', async () => {
+      const params = { severity: 'high', type: 'declining_performance', limit: 5 };
+      await analyticsService.getAlerts(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/alerts', {
+        params,
+      });
+    });
+
+    it('getAlertsSummary llama GET /analytics/alerts/summary', async () => {
+      await analyticsService.getAlertsSummary();
+      expect(mockGet).toHaveBeenCalledWith('/analytics/alerts/summary', {});
+    });
+  });
+
+  // ──────────────── Reports & Export ────────────────
+
+  describe('Reports & Export', () => {
+    it('getStudentReport llama GET /analytics/reports/student/:id con params', async () => {
+      const studentId = 'student-789';
+      const params = { timeRange: '30d', format: 'detailed' };
+      await analyticsService.getStudentReport(studentId, params);
+      expect(mockGet).toHaveBeenCalledWith(
+        `/analytics/reports/student/${studentId}`,
+        { params }
+      );
+    });
+
+    it('getClassroomReport llama GET /analytics/reports/classroom con params', async () => {
+      const params = { timeRange: '30d', format: 'summary' };
+      await analyticsService.getClassroomReport(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/reports/classroom', {
+        params,
+      });
+    });
+
+    it('getClassroomExport llama GET /analytics/reports/classroom/export con params', async () => {
+      const params = { timeRange: '30d' };
+      await analyticsService.getClassroomExport(params);
+      expect(mockGet).toHaveBeenCalledWith('/analytics/reports/classroom/export', {
+        params,
+      });
+    });
+  });
+
+  // ──────────────── Extraccion de datos ────────────────
+
+  describe('Extraccion de datos', () => {
+    it('devuelve los datos extraidos de la respuesta', async () => {
+      const mockData = { students: [{ id: 1, name: 'Test' }], total: 1 };
+      mockGet.mockResolvedValueOnce({ data: { success: true, data: mockData } });
+
+      const result = await analyticsService.getClassroomSummary();
+      expect(result).toEqual(mockData);
+    });
+  });
+});

--- a/frontend/src/services/analytics.js
+++ b/frontend/src/services/analytics.js
@@ -1,8 +1,11 @@
 import api, { extractData } from './api';
 
 const analyticsService = {
+  // ──────────────── Classroom Analytics ────────────────
+
   /**
    * Obtiene el resumen global de la clase (KPIs).
+   * @param {Object} [config] - Configuracion de Axios (AbortController, etc.)
    * @returns {Promise<Object>} KPIs de la clase
    */
   getClassroomSummary: async (config = {}) => {
@@ -11,9 +14,10 @@ const analyticsService = {
   },
 
   /**
-   * Obtiene el progreso comparativo de la clase (gráfico de área/línea).
-   * @param {string} timeRange - '7d' o '30d' (aunque el backend por ahora devuelve 7d)
-   * @returns {Promise<Array>} Datos para el gráfico
+   * Obtiene el progreso comparativo de la clase (grafico de area/linea).
+   * @param {string} [timeRange='7d'] - '7d' o '30d'
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Array>} Datos para el grafico
    */
   getClassroomComparison: async (timeRange = '7d', config = {}) => {
     const response = await api.get('/analytics/classroom/comparison', {
@@ -25,8 +29,9 @@ const analyticsService = {
 
   /**
    * Obtiene tendencias con cambio porcentual (periodo actual vs anterior).
-   * @param {string} timeRange - '7d' o '30d'
-   * @returns {Promise<Object>} KPIs con valores actuales, anteriores y cambio porcentual
+   * @param {string} [timeRange='7d'] - '7d' o '30d'
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} KPIs con current, previous, change, changePercent
    */
   getClassroomTrends: async (timeRange = '7d', config = {}) => {
     const response = await api.get('/analytics/classroom/trends', {
@@ -38,7 +43,8 @@ const analyticsService = {
 
   /**
    * Obtiene las dificultades globales de la clase.
-   * @returns {Promise<Array>}
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Array>} Dificultades por contexto/mecanica
    */
   getClassroomDifficulties: async (config = {}) => {
     const response = await api.get('/analytics/classroom/difficulties', config);
@@ -46,9 +52,97 @@ const analyticsService = {
   },
 
   /**
-   * Obtiene las dificultades de un estudiante específico.
-   * @param {string} studentId
-   * @returns {Promise<Array>} Lista de dificultades por contexto/mecánica
+   * Obtiene la lista de estudiantes con metricas agregadas.
+   * @param {Object} [params] - Query params: sort, order, tier, classroom
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Lista de estudiantes con metricas
+   */
+  getClassroomStudents: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/students', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene la distribucion de rendimiento en 4 rangos (riesgo, promedio, bueno, excelente).
+   * @param {Object} [params] - Query params: timeRange
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Array>} Distribucion [{range, count, percentage}]
+   */
+  getClassroomDistribution: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/distribution', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene el mapa de calor de actividad (dia de la semana x hora).
+   * @param {string} [timeRange='30d'] - '7d' o '30d'
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Datos de heatmap dia x hora
+   */
+  getClassroomHeatmap: async (timeRange = '30d', config = {}) => {
+    const response = await api.get('/analytics/classroom/heatmap', {
+      params: { timeRange },
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene rankings de contextos y mecanicas por uso y rendimiento.
+   * @param {string} [timeRange='30d'] - '7d' o '30d'
+   * @param {number} [limit=10] - Numero maximo de resultados (1-20)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Rankings de contextos y mecanicas
+   */
+  getClassroomRankings: async (timeRange = '30d', limit = 10, config = {}) => {
+    const response = await api.get('/analytics/classroom/rankings', {
+      params: { timeRange, limit },
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene engagement agregado de toda la clase.
+   * @param {Object} [params] - Query params: timeRange, sort, order
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Engagement por estudiante con score desglosado
+   */
+  getClassroomEngagement: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/engagement', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene indicadores de fatiga agregados de la clase.
+   * @param {string} [timeRange='30d'] - '7d' o '30d'
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Indicadores de fatiga (ralentizacion segunda mitad)
+   */
+  getClassroomFatigue: async (timeRange = '30d', config = {}) => {
+    const response = await api.get('/analytics/classroom/fatigue', {
+      params: { timeRange },
+      ...config
+    });
+    return extractData(response);
+  },
+
+  // ──────────────── Student Analytics ────────────────
+
+  /**
+   * Obtiene las dificultades de un estudiante especifico.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Array>} Dificultades por contexto/mecanica
    */
   getStudentDifficulties: async (studentId, config = {}) => {
     const response = await api.get(`/analytics/student/${studentId}/difficulties`, config);
@@ -56,14 +150,279 @@ const analyticsService = {
   },
 
   /**
-   * Obtiene el progreso histórico de un estudiante.
-   * @param {string} studentId
-   * @param {string} timeRange
-   * @returns {Promise<Array>} Datos para el gráfico de progreso
+   * Obtiene el progreso historico de un estudiante.
+   * @param {string} studentId - ID del estudiante
+   * @param {string} [timeRange='30d'] - '7d' o '30d'
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Array>} Datos para el grafico de progreso
    */
   getStudentProgress: async (studentId, timeRange = '30d', config = {}) => {
     const response = await api.get(`/analytics/student/${studentId}/progress`, {
       params: { timeRange },
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene resumen completo de un estudiante (metricas, ultimas partidas, rendimiento, comparativa).
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Resumen completo del estudiante
+   */
+  getStudentSummary: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/summary`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene la trayectoria de aprendizaje con tendencia calculada (mejorando/estable/declinando).
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange (7d/30d/90d), granularity (daily/weekly/monthly)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Progresion temporal con linea de tendencia
+   */
+  getStudentTrajectory: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/trajectory`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene la velocidad de mejora en ventanas temporales.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange, windowDays (3-14)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Tasa de mejora por ventana temporal
+   */
+  getStudentVelocity: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/velocity`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Detecta periodos de estancamiento (plateaus) en el rendimiento.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange, minDays (3-30)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Periodos de estancamiento detectados
+   */
+  getStudentPlateaus: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/plateaus`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene la evolucion del estudiante agrupada por contexto o mecanica.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange, groupBy (context/mechanic)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Evolucion por dimension
+   */
+  getStudentEvolution: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/evolution`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Detecta momentos de dificultad (errores consecutivos / frustracion).
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange, minConsecutiveErrors (2-5)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Momentos de frustracion detectados
+   */
+  getStudentStruggles: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/struggles`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene el engagement score individual con componentes desglosados.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange (30d/90d)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Engagement score con 5 componentes
+   */
+  getStudentEngagement: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/engagement`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene patrones de juego del estudiante.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Patrones de comportamiento en partidas
+   */
+  getStudentPlayPatterns: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/student/${studentId}/play-patterns`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  // ──────────────── Gameplay Analysis ────────────────
+
+  /**
+   * Obtiene el desglose ronda-a-ronda de una partida con deteccion de fatiga.
+   * @param {string} gameplayId - ID del gameplay
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Desglose por rondas con indicador de fatiga
+   */
+  getGameplayRounds: async (gameplayId, config = {}) => {
+    const response = await api.get(`/analytics/gameplay/${gameplayId}/rounds`, config);
+    return extractData(response);
+  },
+
+  // ──────────────── Content Effectiveness ────────────────
+
+  /**
+   * Analiza que contextos/mecanicas producen mejor aprendizaje.
+   * @param {Object} [params] - Query params: timeRange, groupBy (context/mechanic)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Efectividad por contenido
+   */
+  getContentEffectiveness: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/content-effectiveness', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Identifica tarjetas RFID problematicas con alta tasa de error.
+   * @param {Object} [params] - Query params: timeRange, contextId, threshold (10-90)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Tarjetas con mayor dificultad
+   */
+  getCardDifficulty: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/card-difficulty', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene curvas de aprendizaje por contenido (como mejoran con repeticion).
+   * @param {Object} [params] - Query params: timeRange (90d), contextId, mechanicId
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Curvas de aprendizaje por intento
+   */
+  getLearningCurves: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/learning-curves', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Analiza rendimiento por tarjeta RFID (analisis de cartas).
+   * @param {Object} [params] - Query params: timeRange, contextId, limit
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Rendimiento por tarjeta
+   */
+  getCardAnalysis: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/classroom/card-analysis', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  // ──────────────── Alerts ────────────────
+
+  /**
+   * Obtiene alertas inteligentes computadas server-side.
+   * Tipos: declining_performance, inactivity, sudden_score_drop,
+   *        consistent_timeout, improving_fast, plateau_detected, high_abandonment
+   * @param {Object} [params] - Query params: severity, type, limit
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Alertas activas con severidad e interpretacion
+   */
+  getAlerts: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/alerts', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene resumen de alertas (conteos) para badges del sidebar.
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Conteos de alertas por severidad y tipo
+   */
+  getAlertsSummary: async (config = {}) => {
+    const response = await api.get('/analytics/alerts/summary', config);
+    return extractData(response);
+  },
+
+  // ──────────────── Reports & Export ────────────────
+
+  /**
+   * Obtiene datos completos de reporte de un estudiante.
+   * @param {string} studentId - ID del estudiante
+   * @param {Object} [params] - Query params: timeRange, format (summary/detailed)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Datos completos del reporte individual
+   */
+  getStudentReport: async (studentId, params = {}, config = {}) => {
+    const response = await api.get(`/analytics/reports/student/${studentId}`, {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene datos completos de reporte de la clase.
+   * @param {Object} [params] - Query params: timeRange, format (summary/detailed)
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Datos completos del reporte de clase
+   */
+  getClassroomReport: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/reports/classroom', {
+      params,
+      ...config
+    });
+    return extractData(response);
+  },
+
+  /**
+   * Obtiene datos tabulares optimizados para exportacion CSV.
+   * @param {Object} [params] - Query params: timeRange
+   * @param {Object} [config] - Configuracion de Axios
+   * @returns {Promise<Object>} Datos tabulares para CSV
+   */
+  getClassroomExport: async (params = {}, config = {}) => {
+    const response = await api.get('/analytics/reports/classroom/export', {
+      params,
       ...config
     });
     return extractData(response);


### PR DESCRIPTION
## Summary

- **28 endpoints de analytics** (11 básicos + 17 avanzados) con framework KPI, clasificación RAG y narrativas pedagógicas What/So What/Now What
- **4 páginas frontend** (Dashboard mejorado, StudentProfile, StudentsAnalytics, InsightsReports) con 11 componentes reutilizables de analytics
- **Filtros interactivos** de contexto temático, mecánica de juego y rango temporal en Dashboard
- **288 tests nuevos** (164 backend + 124 frontend) cubriendo helpers, endpoints avanzados, servicio, componentes y página Dashboard
- **Consolidación de umbrales RAG** en módulo compartido (`analyticsThresholds.js`) eliminando magic numbers duplicados en 5 componentes
- **Documentación**: ADR-026 a ADR-029, Analytics_Design_Rationale.md (secciones 4.7-4.9)
- **Indices MongoDB** optimizados para queries de analytics

## Detalle por commit

1. **feat: expandir analytics backend** — 19 endpoints avanzados, 6 sub-servicios modulares, framework KPI con 10 definiciones y umbrales RAG, seeders con 60 días de datos temporales
2. **feat: construir suite frontend analytics** — 4 páginas, 11 componentes, 26 métodos en servicio analytics, lazy loading, accesibilidad WCAG 2.2
3. **refactor: consolidar umbrales RAG y filtros** — módulo compartido de thresholds, filtros de contexto/mecánica en Dashboard, cache ligero 60s, tooltips enriquecidos, empty states, responsividad móvil
4. **test: suite de tests analytics** — 102 tests unitarios helpers, 62 tests integración endpoints, 33+36+38+17 tests frontend

## Tareas cerradas

- [x] Backend — Nuevos endpoints de analytics para dashboards
- [x] Backend — Endpoints de analytics avanzados (19 endpoints)
- [x] Dashboard — Eliminar datos mock y conectar datos reales
- [x] Nueva página — Perfil Individual de Estudiante
- [x] Dashboard — KPIs expandidos, filtros interactivos, alertas inteligentes
- [x] Nueva página — Vista Comparativa de Estudiantes con CSV

## Test plan

- [ ] `cd backend && npm test` — 859 tests pasan (695 existentes + 164 nuevos)
- [ ] `cd frontend && npm test` — 204 tests pasan (80 existentes + 124 nuevos)
- [ ] `cd frontend && npm run build` — build exitoso
- [ ] Navegar Dashboard: verificar 8 KPIs, filtros de contexto/mecánica/tiempo, alertas, heatmap
- [ ] Navegar `/students/:id`: verificar KPIs individuales, trayectoria, engagement radar, historial
- [ ] Navegar `/analytics/students`: verificar tabla ordenable, filtrable, exportación CSV
- [ ] Navegar `/analytics/insights`: verificar matriz efectividad, alertas hub, generador reportes
- [ ] Verificar responsividad en viewport ≥768px