### PR TITLE
fix: URLs de API y WebSocket del frontend quedaban fijas a localhost en Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,14 @@ services:
     build:
       context: ./frontend
       args:
-        - VITE_API_URL=http://localhost/api
+        # Rutas relativas al propio origen: el Nginx del contenedor frontend
+        # (nginx.conf) ya proxea /api y /socket.io/ al backend, así que el
+        # navegador siempre las resuelve contra el dominio real desde el que
+        # se sirvió la página (localhost en dev, el dominio real en la VPS)
+        # sin necesitar un build-arg distinto por entorno. VITE_SOCKET_URL
+        # vacía (no ausente) le indica a socket.js que use el mismo origen.
+        - VITE_API_URL=/api
+        - VITE_SOCKET_URL=
     restart: unless-stopped
     read_only: true
     tmpfs:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,11 @@ WORKDIR /app
 ARG VITE_API_URL
 ENV VITE_API_URL=$VITE_API_URL
 
+# URL del servidor Socket.IO. Vacía (no ausente) señaliza "mismo origen que la
+# página" a socket.js — ver comentario en docker-compose.yml.
+ARG VITE_SOCKET_URL
+ENV VITE_SOCKET_URL=$VITE_SOCKET_URL
+
 # Modo de build de Vite. Por defecto `production` (bundle real de despliegue).
 # Para sesiones de QA con sensor simulado se puede construir con
 # `docker compose build --build-arg VITE_BUILD_MODE=development frontend`,

--- a/frontend/src/services/socket.js
+++ b/frontend/src/services/socket.js
@@ -12,7 +12,14 @@ import { getAccessToken, AUTH_EVENTS } from './api';
 // CONFIGURACIÓN
 // ============================================
 
-const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:5000';
+// `npm run dev` (Vite en :5173, backend en :5000, origen distinto) no define
+// la variable -> fallback absoluto a localhost:5000. En builds Docker (local,
+// staging, producción) el build-arg siempre está definido, aunque sea vacío,
+// para indicar "mismo origen que la página" -> `undefined` hace que
+// socket.io-client conecte al host real que sirvió el bundle, sin necesitar
+// conocer el dominio en tiempo de build (igual que VITE_API_URL=/api).
+const rawSocketUrl = import.meta.env.VITE_SOCKET_URL;
+const SOCKET_URL = rawSocketUrl === undefined ? 'http://localhost:5000' : rawSocketUrl || undefined;
 const RECONNECTION_ATTEMPTS = 15;
 const RECONNECTION_DELAY = 1000;
 // Tope del backoff: bajado de 15s a 5s para reaccionar antes a redeploys cloud.
@@ -291,7 +298,11 @@ class SocketService {
     const systemPromise = this._connectNamespace('system', SOCKET_URL, opts);
 
     // --- Socket de juego (namespace /game) ---
-    const gamePromise = this._connectNamespace('game', `${SOCKET_URL  }/game`, opts);
+    // Con SOCKET_URL undefined (mismo origen), concatenar `${SOCKET_URL}/game`
+    // daría el string literal "undefined/game". Pasando solo "/game",
+    // socket.io-client conecta ese namespace al mismo origen que la página.
+    const gameNamespaceUrl = SOCKET_URL === undefined ? '/game' : `${SOCKET_URL}/game`;
+    const gamePromise = this._connectNamespace('game', gameNamespaceUrl, opts);
 
     this._connectPromise = Promise.all([systemPromise, gamePromise])
       .then(() => undefined)


### PR DESCRIPTION
## Resumen

- `VITE_API_URL` se pasaba como build-arg literal `http://localhost/api` en `docker-compose.yml`, y `VITE_SOCKET_URL` nunca se declaraba como `ARG` en `frontend/Dockerfile`.
- Vite incrusta esas variables en el bundle JS **en tiempo de build**, no en runtime. Cualquier usuario real (staging o producción) recibía un JS que intentaba conectar a `http://localhost/api` y `http://localhost:5000` — es decir, a su propia máquina — en vez del dominio real. Esto rompía login (POST no idempotente, sin retry) y WebSocket en ambos entornos.
- Confirmado descargando y desminificando el bundle JS real servido por `eduplay-tfg-staging.duckdns.org` y `eduplay-tfg.duckdns.org`: ambos contenían literalmente `http://localhost/api` / `http://localhost:5000`.
- El smoke test del pipeline de deploy (`curl 127.0.0.1:PORT/api/health/ready`) no lo detecta porque prueba el backend por loopback directamente en el VPS, no el JS que recibe un navegador externo.

## Fix

Ambas variables pasan a ser relativas al origen (`VITE_API_URL=/api`, `VITE_SOCKET_URL=` vacía) — el `nginx.conf` del contenedor frontend ya proxea `/api/` y `/socket.io/` al backend en el mismo origen, así que funciona igual en local, staging y producción sin overrides por entorno. De paso corrige un segundo bug en `socket.js`: con `SOCKET_URL` vacío, el namespace `/game` se construía por concatenación de plantilla y habría producido el string literal `"undefined/game"`.

## Test plan

- [x] `npm run lint` (frontend) limpio
- [x] `npx vitest run` (frontend) — 679/679 tests pasando
- [x] Build local reproduciendo los build-args del pipeline (antes: bundle con `localhost/api`/`localhost:5000` confirmado; después: bundle con `/api` y `undefined`/`/game`, sin restos de `localhost`)
- [ ] Verificar login en staging tras el deploy